### PR TITLE
Update to newer Rust

### DIFF
--- a/ncollide_utils/data/hash.rs
+++ b/ncollide_utils/data/hash.rs
@@ -9,7 +9,7 @@ pub trait HashFun<K> {
 }
 
 /// Hash function for pairs of `usize`, using the Tomas Wang hash.
-#[derive(Clone, RustcEncodable, RustcDecodable)]
+#[derive(Clone, Encodable, Decodable)]
 pub struct UintPairTWHash { unused: usize }
 
 impl UintPairTWHash {
@@ -34,7 +34,7 @@ impl HashFun<(usize, usize)> for UintPairTWHash {
 }
 
 /// Hash function for `usize`.
-#[derive(Clone, RustcEncodable, RustcDecodable)]
+#[derive(Clone, Encodable, Decodable)]
 pub struct UintTWHash { unused: usize } // FIXME: ICE if the struct is zero-sized
 
 impl UintTWHash {

--- a/ncollide_utils/data/hash_map.rs
+++ b/ncollide_utils/data/hash_map.rs
@@ -1,6 +1,5 @@
 //! An hash map with a customizable hash function.
 
-use std::num::UnsignedInt;
 use std::mem;
 use std::iter;
 use data::hash::HashFun;
@@ -52,7 +51,7 @@ impl<K, V, H: HashFun<K>> HashMap<K, V, H> {
 
     /// Creates a new hash map with a given capacity.
     pub fn new_with_capacity(capacity: usize, h: H) -> HashMap<K, V, H> {
-        let pow2 = UnsignedInt::next_power_of_two(capacity);
+        let pow2 = capacity.next_power_of_two();
 
         HashMap {
             hash:   h,

--- a/ncollide_utils/data/hash_map.rs
+++ b/ncollide_utils/data/hash_map.rs
@@ -5,7 +5,7 @@ use std::iter;
 use data::hash::HashFun;
 
 /// Entry of an `HashMap`.
-#[derive(Clone, RustcEncodable, RustcDecodable)]
+#[derive(Clone, Encodable, Decodable)]
 pub struct Entry<K, V> {
     /// The key of the entry.
     pub key:   K,
@@ -29,7 +29,7 @@ impl<K, V> Entry<K, V> {
 /// * the hash function can be personalized
 /// * the hash table is separate from the data. Thus, the vector of entries is tight (no holes
 ///     due to sparse hashing).
-#[derive(Clone, RustcEncodable, RustcDecodable)]
+#[derive(Clone, Encodable, Decodable)]
 pub struct HashMap<K, V, H> {
     hash:          H,
     table:         Vec<Entry<K, V>>,

--- a/ncollide_utils/data/pair.rs
+++ b/ncollide_utils/data/pair.rs
@@ -7,7 +7,7 @@ use data::uid_remap::FastKey;
 // XXX: Rename this `FastKeyPair`.
 
 /// An unordered pair of elements implementing `HasUid`.
-#[derive(Clone, Copy, RustcEncodable, RustcDecodable)]
+#[derive(Clone, Copy, Encodable, Decodable)]
 pub struct Pair {
     /// first object of the pair
     pub first:  FastKey,
@@ -45,7 +45,7 @@ impl PartialEq for Pair {
 }
 
 /// Tomas Wang based hash function for a `Pair` object.
-#[derive(RustcEncodable, RustcDecodable)]
+#[derive(Encodable, Decodable)]
 pub struct PairTWHash { unused: usize } // FIXME: ICE with zero-sized structs
 
 impl PairTWHash {

--- a/ncollide_utils/data/uid_remap.rs
+++ b/ncollide_utils/data/uid_remap.rs
@@ -11,7 +11,7 @@ use std::collections::{VecMap, HashMap};
 
 /// A special type of key used by `UidRemap` to perform faster lookups than with the user-defined
 /// id of type `usize`.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable)]
 pub struct FastKey {
     uid: usize
 }
@@ -32,14 +32,14 @@ impl FastKey {
     }
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Encodable, Decodable)]
 struct LookupData {
     uid2key:   HashMap<usize, FastKey>,
     free_keys: Vec<FastKey>,
 }
 
 /// A set of values having large usize key.
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Encodable, Decodable)]
 pub struct UidRemap<O> { // FIXME: find a better name.
     values: VecMap<O>,
     lookup: Option<LookupData>

--- a/ncollide_utils/hashable_partial_eq.rs
+++ b/ncollide_utils/hashable_partial_eq.rs
@@ -3,7 +3,7 @@ use AsBytes;
 
 /// A structure that implements `Eq` and is hashable even if the wrapped data implements only
 /// `PartialEq`.
-#[derive(PartialEq, RustcEncodable, RustcDecodable, Clone, Rand, Debug)]
+#[derive(PartialEq, Encodable, Decodable, Clone, Rand, Debug)]
 pub struct HashablePartialEq<T> {
     value: T
 }

--- a/ncollide_utils/lib.rs
+++ b/ncollide_utils/lib.rs
@@ -14,7 +14,7 @@
 #![doc(html_root_url = "http://ncollide.org/doc")]
 
 extern crate rand;
-extern crate "rustc-serialize" as rustc_serialize;
+extern crate serialize;
 extern crate "nalgebra" as na;
 extern crate "ncollide_math" as math;
 


### PR DESCRIPTION
Despite what Travis says, `ncollide` master does not compile with `rustc` master. There were two issues, dealt with in two commits:

 - `std::num::UnsignedInt` was deprecated; you can just use its methods now without needing the trait. That was straightforward, in the first commit.
 - There is now a `serialize` crate, and `std` objects now derive from it and not from `rustc-serialize`. I went through and changed `rustc-serialize` -> `serialize`, `RustcEncodable` -> `Encodable`, `RustcDecodable` -> `Decodable`.

There are still a large number of deprecation warnings which I did not address, but it does compile.