### PR TITLE
Fix ball-vs-ball TOI whenever the ray has a non-unit direction.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ ncollide_queries = "*"
 ncollide_pipeline = "*"
 ncollide_procedural = "*"
 ncollide_transformation = "*"
+
+[dev-dependencies]
+nalgebra = "*"

--- a/ncollide_queries/Cargo.toml
+++ b/ncollide_queries/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ncollide_queries"
-version = "0.2.3"
+version = "0.2.4"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 and 3-dimensional collision detection library in Rust: module for geometric queries like distances computation, ray casting and contact determination."

--- a/ncollide_queries/ray/ray_ball.rs
+++ b/ncollide_queries/ray/ray_ball.rs
@@ -67,6 +67,7 @@ pub fn ball_toi_with_ray<P>(center: &P,
     where P: Point {
     let dcenter = ray.orig - *center;
 
+    let a = na::sqnorm(&ray.dir);
     let b = na::dot(&dcenter, &ray.dir);
     let c = na::sqnorm(&dcenter) - radius * radius;
 
@@ -74,14 +75,14 @@ pub fn ball_toi_with_ray<P>(center: &P,
         (false, None)
     }
     else {
-        let delta = b * b - c;
+        let delta = b * b - a * c;
 
         if delta < na::zero() {
             // no solution
             (false, None)
         }
         else {
-            let t = -b - delta.sqrt();
+            let t = (-b - delta.sqrt()) / a;
 
             if t <= na::zero() {
                 // orig inside of the ball
@@ -89,7 +90,7 @@ pub fn ball_toi_with_ray<P>(center: &P,
                     (true, Some(na::zero()))
                 }
                 else {
-                    (true, Some(-b + delta.sqrt()))
+                    (true, Some((-b + delta.sqrt()) / a))
                 }
             }
             else {

--- a/ncollide_queries/ray/ray_support_map.rs
+++ b/ncollide_queries/ray/ray_support_map.rs
@@ -28,9 +28,10 @@ pub fn implicit_toi_and_normal_with_ray<P, M, S, G: ?Sized>(m:       &M,
             Some((toi, normal)) => {
                 if na::is_zero(&toi) {
                     // the ray is inside of the shape.
-                    let supp    = shape.support_point(m, &ray.dir);
-                    let shift   = na::dot(&(supp - ray.orig), &ray.dir) + na::cast(0.001f64);
-                    let new_ray = Ray::new(ray.orig + ray.dir * shift, -ray.dir);
+                    let ndir    = na::normalize(&ray.dir);
+                    let supp    = shape.support_point(m, &ndir);
+                    let shift   = na::dot(&(supp - ray.orig), &ndir) + na::cast(0.001f64);
+                    let new_ray = Ray::new(ray.orig + ndir * shift, -ray.dir);
 
                     // FIXME: replace by? : simplex.translate_by(&(ray.orig - new_ray.orig));
                     simplex.reset(supp + (-*new_ray.orig.as_vec()));

--- a/tests/ball_ball_toi.rs
+++ b/tests/ball_ball_toi.rs
@@ -1,0 +1,19 @@
+// Issue #35
+
+extern crate nalgebra as na;
+extern crate ncollide;
+
+use na::{Iso3, Vec3};
+use ncollide::shape::Ball;
+use ncollide::geometry;
+
+#[test]
+fn test_ball_ball_toi() {
+    let b  = Ball::new(0.5f64);
+    let m1 = Iso3::new(na::zero(), na::zero());
+    let m2 = Iso3::new(na::Vec3::new(0.0, 10.0, 0.0), na::zero());
+
+    let cast = geometry::time_of_impact(&m1, &Vec3::new(0.0, 10.0, 0.0), &b, &m2, &na::zero(), &b);
+
+    assert_eq!(cast.unwrap(), 0.9);
+}


### PR DESCRIPTION
While attempting to fix a regression on `nrays` scenes involving balls, I ended up fixing this.

Fix #35.