### PR TITLE
Add point and matrix type parameters to the `ReprDesc`.

### DIFF
--- a/ncollide_entities/Cargo.toml
+++ b/ncollide_entities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ncollide_entities"
-version = "0.2.1"
+version = "0.2.2"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 and 3-dimensional collision detection library in Rust: module describing the geometric entities and their mathematical definitions."

--- a/ncollide_entities/inspection/maybe_as_composite_shape.rs
+++ b/ncollide_entities/inspection/maybe_as_composite_shape.rs
@@ -11,7 +11,7 @@ pub fn composite_shape_repr_id<P: Any, M: Any>() -> TypeId {
 
 /// Converts a shape to a composite shape if possible.
 #[inline]
-pub fn maybe_repr_desc_as_composite_shape<'a, P: Any, M: Any>(desc: ReprDesc<'a>) -> Option<&'a (CompositeShape<P, M> + 'a)> {
+pub fn maybe_repr_desc_as_composite_shape<'a, P: Any, M: Any>(desc: ReprDesc<'a, P, M>) -> Option<&'a (CompositeShape<P, M> + 'a)> {
     if desc.repr_id() == composite_shape_repr_id::<P, M>() {
         Some(unsafe { mem::transmute(desc.repr()) })
     }
@@ -35,7 +35,7 @@ macro_rules! impl_composite_shape_repr(
             where P: Point,
                   M: Isometry<P, P::Vect> {
                 #[inline(always)]
-                fn repr(&self) -> ReprDesc {
+                fn repr(&self) -> ReprDesc<P, M> {
                     unsafe {
                         ReprDesc::new(
                             TypeId::of::<$t>(),

--- a/ncollide_entities/inspection/maybe_as_support_map.rs
+++ b/ncollide_entities/inspection/maybe_as_support_map.rs
@@ -12,7 +12,7 @@ pub fn support_map_repr_id<P: Any, M: Any>() -> TypeId {
 
 /// Converts a shape descriptor to a support map if possible.
 #[inline]
-pub fn maybe_repr_desc_as_support_map<'a, P: Any, M: Any>(desc: ReprDesc<'a>) -> Option<&'a (SupportMap<P, M> + 'a)> {
+pub fn maybe_repr_desc_as_support_map<'a, P: Any, M: Any>(desc: ReprDesc<'a, P, M>) -> Option<&'a (SupportMap<P, M> + 'a)> {
     if desc.repr_id() == support_map_repr_id::<P, M>() {
         Some(unsafe { mem::transmute(desc.repr()) })
     }
@@ -36,7 +36,7 @@ macro_rules! impl_support_map_repr(
             where P: Point,
                   M: Isometry<P, P::Vect> {
                 #[inline(always)]
-                fn repr(&self) -> ReprDesc {
+                fn repr(&self) -> ReprDesc<P, M> {
                     unsafe {
                         ReprDesc::new(
                             TypeId::of::<$t>(),

--- a/ncollide_entities/inspection/mod.rs
+++ b/ncollide_entities/inspection/mod.rs
@@ -23,3 +23,7 @@ mod maybe_as_support_map;
 pub type Repr2<N> = Repr<Pnt2<N>, Iso2<N>>;
 /// A 3d dynamic representation object.
 pub type Repr3<N> = Repr<Pnt3<N>, Iso3<N>>;
+/// A 2d dynamic representation descriptor.
+pub type ReprDesc2<'a, N> = ReprDesc<'a, Pnt2<N>, Iso2<N>>;
+/// A 3d dynamic representation descriptor.
+pub type ReprDesc3<'a, N> = ReprDesc<'a, Pnt3<N>, Iso3<N>>;

--- a/ncollide_entities/inspection/repr.rs
+++ b/ncollide_entities/inspection/repr.rs
@@ -15,24 +15,28 @@ pub struct TraitObject {
 }
 
 #[derive(Clone, Copy)]
-pub struct ReprDesc<'a> {
-    type_id: TypeId,
-    repr_id: TypeId,
-    repr:    TraitObject,
-    life:    PhantomData<fn() -> &'a ()>
+pub struct ReprDesc<'a, P, M> {
+    type_id:      TypeId,
+    repr_id:      TypeId,
+    repr:         TraitObject,
+    life:         PhantomData<fn() -> &'a ()>,
+    _point_type:  PhantomData<P>,
+    _matrix_type: PhantomData<M>,
 }
 
-impl<'a> ReprDesc<'a> {
+impl<'a, P, M> ReprDesc<'a, P, M> {
     /// Creates a new representation descriptor.
     ///
     /// This is unsafe as there is no way to check that the given triple of data are valid.
     #[inline]
-    pub unsafe fn new(type_id: TypeId, repr_id: TypeId, repr: TraitObject) -> ReprDesc<'a> {
+    pub unsafe fn new(type_id: TypeId, repr_id: TypeId, repr: TraitObject) -> ReprDesc<'a, P, M> {
         ReprDesc {
-            type_id: type_id,
-            repr_id: repr_id,
-            repr:    repr,
-            life:    PhantomData
+            type_id:      type_id,
+            repr_id:      repr_id,
+            repr:         repr,
+            life:         PhantomData,
+            _point_type:  PhantomData,
+            _matrix_type: PhantomData,
         }
     }
 
@@ -69,5 +73,5 @@ impl<'a> ReprDesc<'a> {
 /// An object with a unique runtime geometric representation.
 pub trait Repr<P, M>: Send + Sync + 'static {
     /// Gets a reference to this object's main representation.
-    fn repr<'a>(&'a self) -> ReprDesc<'a>;
+    fn repr<'a>(&'a self) -> ReprDesc<'a, P, M>;
 }

--- a/ncollide_entities/shape/plane.rs
+++ b/ncollide_entities/shape/plane.rs
@@ -40,7 +40,7 @@ impl<V> Plane<V> {
 impl<P, M> Repr<P, M> for Plane<P::Vect>
     where P: Point {
     #[inline(always)]
-    fn repr(&self) -> ReprDesc {
+    fn repr(&self) -> ReprDesc<P, M> {
         unsafe {
             ReprDesc::new(
                 TypeId::of::<Plane<P::Vect>>(),

--- a/ncollide_pipeline/Cargo.toml
+++ b/ncollide_pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ncollide_pipeline"
-version = "0.2.2"
+version = "0.2.3"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 and 3-dimensional collision detection library in Rust: module describing the collision detection pipeline (broad phase/narrow phase) of ncollide."

--- a/ncollide_pipeline/narrow_phase/collision_detector.rs
+++ b/ncollide_pipeline/narrow_phase/collision_detector.rs
@@ -28,5 +28,5 @@ pub type CollisionAlgorithm<P, M> = Box<CollisionDetector<P, M> + 'static>;
 
 pub trait CollisionDispatcher<P, M> {
     /// Allocate a collision algorithm corresponding to the given pair of shapes.
-    fn get_collision_algorithm(&self, a: &ReprDesc, b: &ReprDesc) -> Option<CollisionAlgorithm<P, M>>;
+    fn get_collision_algorithm(&self, a: &ReprDesc<P, M>, b: &ReprDesc<P, M>) -> Option<CollisionAlgorithm<P, M>>;
 }


### PR DESCRIPTION
This make type inference more available whenever the `Repr` trait is used.
As a side effect, the `BasicCollisionDispatcher` now takes two type parameters `P` and `M` for the point and matrix types.