### PR TITLE
Add free functions to compute the bounding sphere or box.

### DIFF
--- a/ncollide_entities/Cargo.toml
+++ b/ncollide_entities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ncollide_entities"
-version = "0.2.2"
+version = "0.2.3"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 and 3-dimensional collision detection library in Rust: module describing the geometric entities and their mathematical definitions."

--- a/ncollide_entities/bounding_volume/aabb.rs
+++ b/ncollide_entities/bounding_volume/aabb.rs
@@ -12,6 +12,15 @@ pub trait HasAABB<P, M> {
     fn aabb(&self, &M) -> AABB<P>;
 }
 
+// Seems useful to help type inference. See issue #84.
+/// Computes the axis-aligned bounding box of a shape `g` transformed by `m`.
+///
+/// Same as `g.aabb(m)`.
+pub fn aabb<P, M, G>(g: &G, m: &M) -> AABB<P>
+    where G: HasAABB<P, M> {
+    g.aabb(m)
+}
+
 /// An Axis Aligned Bounding Box.
 #[derive(Debug, PartialEq, Clone, RustcEncodable, RustcDecodable)]
 pub struct AABB<P> {

--- a/ncollide_entities/bounding_volume/bounding_sphere.rs
+++ b/ncollide_entities/bounding_volume/bounding_sphere.rs
@@ -11,6 +11,16 @@ pub trait HasBoundingSphere<P, M> {
     fn bounding_sphere(&self, m: &M) -> BoundingSphere<P>;
 }
 
+// Seems useful to help type inference. See issue #84.
+/// Computes the bounding sphere of a shape `g` transformed by `m`.
+///
+/// Same as `g.bounding_sphere(m)`.
+pub fn bounding_sphere<P, M, G>(g: &G, m: &M) -> BoundingSphere<P>
+    where P: Point,
+          G: HasBoundingSphere<P, M> {
+    g.bounding_sphere(m)
+}
+
 /// A Bounding Sphere.
 #[derive(Debug, PartialEq, Clone, RustcEncodable, RustcDecodable)]
 pub struct BoundingSphere<P: Point> {

--- a/ncollide_entities/bounding_volume/mod.rs
+++ b/ncollide_entities/bounding_volume/mod.rs
@@ -3,9 +3,9 @@
 #[doc(inline)]
 pub use bounding_volume::bounding_volume::{HasBoundingVolume, BoundingVolume};
 #[doc(inline)]
-pub use bounding_volume::aabb::{HasAABB, AABB};
+pub use bounding_volume::aabb::{HasAABB, AABB, aabb};
 #[doc(inline)]
-pub use bounding_volume::bounding_sphere::{HasBoundingSphere, BoundingSphere};
+pub use bounding_volume::bounding_sphere::{HasBoundingSphere, BoundingSphere, bounding_sphere};
 
 pub use bounding_volume::aabb_utils::{implicit_shape_aabb, point_cloud_aabb};
 pub use bounding_volume::aabb_ball::ball_aabb;


### PR DESCRIPTION
For some reason, the compiler manages to infer types properly using the free functions, while it
fails when the user calls the (HasBoundingSphere and HasAABB) traits' methods directly.

Closes #84.