### PR TITLE
make CollisionWorld{2/3} public

### DIFF
--- a/ncollide_pipeline/world/mod.rs
+++ b/ncollide_pipeline/world/mod.rs
@@ -14,6 +14,6 @@ mod collision_world;
 
 
 /// A 3D collision world associating collision objects to user-defined data of type `T`.
-type CollisionWorld3<N, T> = CollisionWorld<Pnt3<N>, Iso3<N>, T>;
+pub type CollisionWorld3<N, T> = CollisionWorld<Pnt3<N>, Iso3<N>, T>;
 /// A 2D collision world associating collision objects to user-defined data of type `T`.
-type CollisionWorld2<N, T> = CollisionWorld<Pnt2<N>, Iso2<N>, T>;
+pub type CollisionWorld2<N, T> = CollisionWorld<Pnt2<N>, Iso2<N>, T>;


### PR DESCRIPTION
The types were still private, meaning client code would not be able to use them.