### PR TITLE
Remove the `HasAABB` and `HasBoundingSphere` traits.

### DIFF
--- a/examples/aabb2d.rs
+++ b/examples/aabb2d.rs
@@ -16,15 +16,15 @@ fn main() {
     let cylinder_pos = na::one::<Iso2<f32>>();           // Identity matrix.
 
     /*
-     * Compute their bounding spheres.
+     * Compute their axis-aligned bounding boxes.
      */
     let aabb_cone     = bounding_volume::aabb(&cone, &cone_pos);
     let aabb_cylinder = bounding_volume::aabb(&cylinder, &cylinder_pos);
 
-    // Merge the two spheres.
+    // Merge the two boxes.
     let bounding_aabb = aabb_cone.merged(&aabb_cylinder);
 
-    // Enlarge the cylinder bounding sphere.
+    // Enlarge the cylinder aabb.
     let loose_aabb_cylinder = aabb_cylinder.loosened(1.0);
 
     // Intersection and inclusion tests.

--- a/examples/aabb3d.rs
+++ b/examples/aabb3d.rs
@@ -16,15 +16,15 @@ fn main() {
     let cylinder_pos = na::one::<Iso3<f32>>();           // Identity matrix.
 
     /*
-     * Compute their bounding spheres.
+     * Compute their axis-aligned bounding boxes.
      */
     let aabb_cone     = bounding_volume::aabb(&cone, &cone_pos);
     let aabb_cylinder = bounding_volume::aabb(&cylinder, &cylinder_pos);
 
-    // Merge the two spheres.
+    // Merge the two boxes.
     let bounding_aabb = aabb_cone.merged(&aabb_cylinder);
 
-    // Enlarge the cylinder bounding sphere.
+    // Enlarge the cylinder aabb.
     let loose_aabb_cylinder = aabb_cylinder.loosened(1.0);
 
     // Intersection and inclusion tests.

--- a/examples/ray_bvt2d.rs
+++ b/examples/ray_bvt2d.rs
@@ -5,17 +5,17 @@ use na::{Pnt2, Vec2, Iso2};
 use ncollide::partitioning::BVT;
 use ncollide::shape::{Cone, Ball, Cuboid, Capsule};
 use ncollide::ray::{RayInterferencesCollector, Ray, RayCast};
-use ncollide::bounding_volume::HasBoundingSphere;
+use ncollide::bounding_volume::{self, BoundingSphere, HasBoundingVolume};
 
 /*
  * Custom trait to group `HasBoudingSphere` and `RayCast` together.
  */
-trait Shape2: HasBoundingSphere<Pnt2<f64>, Iso2<f64>> +
+trait Shape2: HasBoundingVolume<Iso2<f64>, BoundingSphere<Pnt2<f64>>> +
               RayCast<Pnt2<f64>, Iso2<f64>> {
 }
 
 impl<T> Shape2 for T
-    where T: HasBoundingSphere<Pnt2<f64>, Iso2<f64>> +
+    where T: HasBoundingVolume<Iso2<f64>, BoundingSphere<Pnt2<f64>>> +
              RayCast<Pnt2<f64>, Iso2<f64>> {
 }
 
@@ -39,11 +39,12 @@ fn main() {
         Iso2::new(Vec2::new(4.0, 2.0), na::zero())
     ];
 
-    let idx_and_bounding_spheres  = vec!(
-        (0usize, shapes[0].bounding_sphere(&poss[0])),
-        (1usize, shapes[1].bounding_sphere(&poss[1])),
-        (2usize, shapes[2].bounding_sphere(&poss[2])),
-        (3usize, shapes[3].bounding_sphere(&poss[3]))
+    // FIXME: why do we need the explicit type annotation here?
+    let idx_and_bounding_spheres: Vec<(usize, BoundingSphere<Pnt2<f64>>)> = vec!(
+        (0usize, bounding_volume::bounding_sphere(shapes[0], &poss[0])),
+        (1usize, bounding_volume::bounding_sphere(shapes[1], &poss[1])),
+        (2usize, bounding_volume::bounding_sphere(shapes[2], &poss[2])),
+        (3usize, bounding_volume::bounding_sphere(shapes[3], &poss[3]))
     );
 
     let bvt      = BVT::new_balanced(idx_and_bounding_spheres);

--- a/examples/ray_bvt3d.rs
+++ b/examples/ray_bvt3d.rs
@@ -5,17 +5,17 @@ use na::{Pnt3, Vec3, Iso3};
 use ncollide::partitioning::BVT;
 use ncollide::shape::{Cone, Ball, Cuboid, Capsule};
 use ncollide::ray::{RayInterferencesCollector, RayCast, Ray};
-use ncollide::bounding_volume::HasBoundingSphere;
+use ncollide::bounding_volume::{self, BoundingSphere, HasBoundingVolume};
 
 /*
  * Custom trait to group `HasBoudingSphere` and `RayCast` together.
  */
-trait Shape3: HasBoundingSphere<Pnt3<f64>, Iso3<f64>> +
+trait Shape3: HasBoundingVolume<Iso3<f64>, BoundingSphere<Pnt3<f64>>> +
               RayCast<Pnt3<f64>, Iso3<f64>> {
 }
 
 impl<T> Shape3 for T
-    where T: HasBoundingSphere<Pnt3<f64>, Iso3<f64>> +
+    where T: HasBoundingVolume<Iso3<f64>, BoundingSphere<Pnt3<f64>>> +
              RayCast<Pnt3<f64>, Iso3<f64>> {
 }
 
@@ -39,11 +39,11 @@ fn main() {
         Iso3::new(Vec3::new(0.0, 2.0, 4.0), na::zero())
     ];
 
-    let idx_and_bounding_spheres  = vec!(
-        (0usize, shapes[0].bounding_sphere(&poss[0])),
-        (1usize, shapes[1].bounding_sphere(&poss[1])),
-        (2usize, shapes[2].bounding_sphere(&poss[2])),
-        (3usize, shapes[3].bounding_sphere(&poss[3]))
+    let idx_and_bounding_spheres: Vec<(usize, BoundingSphere<Pnt3<f64>>)> = vec!(
+        (0usize, bounding_volume::bounding_sphere::<Pnt3<f64>, _, _>(shapes[0], &poss[0])),
+        (1usize, bounding_volume::bounding_sphere(shapes[1], &poss[1])),
+        (2usize, bounding_volume::bounding_sphere(shapes[2], &poss[2])),
+        (3usize, bounding_volume::bounding_sphere(shapes[3], &poss[3]))
     );
 
     let bvt      = BVT::new_balanced(idx_and_bounding_spheres);

--- a/ncollide_entities/Cargo.toml
+++ b/ncollide_entities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ncollide_entities"
-version = "0.2.3"
+version = "0.3.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 and 3-dimensional collision detection library in Rust: module describing the geometric entities and their mathematical definitions."

--- a/ncollide_entities/bounding_volume/aabb.rs
+++ b/ncollide_entities/bounding_volume/aabb.rs
@@ -3,22 +3,16 @@
 use std::ops::Neg;
 use na::{Translation, POrd, Translate, Bounded};
 use na;
-use bounding_volume::BoundingVolume;
+use bounding_volume::{BoundingVolume, HasBoundingVolume};
 use math::{Scalar, Point, Vect};
-
-/// Trait of objects that can be bounded by an AABB.
-pub trait HasAABB<P, M> {
-    /// The object’s AABB.
-    fn aabb(&self, &M) -> AABB<P>;
-}
 
 // Seems useful to help type inference. See issue #84.
 /// Computes the axis-aligned bounding box of a shape `g` transformed by `m`.
 ///
 /// Same as `g.aabb(m)`.
-pub fn aabb<P, M, G>(g: &G, m: &M) -> AABB<P>
-    where G: HasAABB<P, M> {
-    g.aabb(m)
+pub fn aabb<P, M, G: ?Sized>(g: &G, m: &M) -> AABB<P>
+    where G: HasBoundingVolume<M, AABB<P>> {
+    g.bounding_volume(m)
 }
 
 /// An Axis Aligned Bounding Box.

--- a/ncollide_entities/bounding_volume/aabb_ball.rs
+++ b/ncollide_entities/bounding_volume/aabb_ball.rs
@@ -1,6 +1,6 @@
 use na::Translate;
 use na;
-use bounding_volume::{HasAABB, AABB};
+use bounding_volume::{HasBoundingVolume, AABB};
 use shape::Ball;
 use math::{Scalar, Point, Vect};
 
@@ -11,11 +11,11 @@ pub fn ball_aabb<P>(center: &P, radius: <P::Vect as Vect>::Scalar) -> AABB<P>
     AABB::new(*center + na::repeat(-radius), *center + na::repeat(radius))
 }
 
-impl<P, M> HasAABB<P, M> for Ball<<P::Vect as Vect>::Scalar>
+impl<P, M> HasBoundingVolume<M, AABB<P>> for Ball<<P::Vect as Vect>::Scalar>
     where P: Point,
           M: Translate<P> {
     #[inline]
-    fn aabb(&self, m: &M) -> AABB<P> {
+    fn bounding_volume(&self, m: &M) -> AABB<P> {
         ball_aabb(&m.translate(&na::orig()), self.radius())
     }
 }

--- a/ncollide_entities/bounding_volume/aabb_bezier_curve.rs
+++ b/ncollide_entities/bounding_volume/aabb_bezier_curve.rs
@@ -1,12 +1,12 @@
-use bounding_volume::{AABB, HasAABB};
+use bounding_volume::{AABB, HasBoundingVolume};
 use bounding_volume::aabb_utils;
 use shape::BezierCurve;
 use math::Matrix;
 use math::{Scalar, Point, Vect};
 
-impl HasAABB for BezierCurve {
+impl HasBoundingVolume for BezierCurve {
     #[inline]
-    fn aabb(&self, m: &Matrix) -> AABB {
+    fn bounding_volume(&self, m: &Matrix) -> AABB {
         aabb_utils::point_cloud_aabb(m, self.control_points())
     }
 }

--- a/ncollide_entities/bounding_volume/aabb_compound.rs
+++ b/ncollide_entities/bounding_volume/aabb_compound.rs
@@ -1,15 +1,15 @@
 use na::{Translation, AbsoluteRotate, Transform, Translate};
 use na;
-use bounding_volume::{AABB, HasAABB};
+use bounding_volume::{AABB, HasBoundingVolume};
 use shape::Compound;
 use math::{Scalar, Point, Vect};
 
-impl<P, M, M2> HasAABB<P, M2> for Compound<P, M>
+impl<P, M, M2> HasBoundingVolume<M2, AABB<P>> for Compound<P, M>
     where P: Point,
           P::Vect: Translate<P>,
           M2: Transform<P> + AbsoluteRotate<P::Vect> {
     #[inline]
-    fn aabb(&self, m: &M2) -> AABB<P> {
+    fn bounding_volume(&self, m: &M2) -> AABB<P> {
         let bv              = self.bvt().root_bounding_volume().unwrap();
         let ls_center       = na::orig::<P>() + bv.translation();
         let center          = m.transform(&ls_center);

--- a/ncollide_entities/bounding_volume/aabb_convex.rs
+++ b/ncollide_entities/bounding_volume/aabb_convex.rs
@@ -1,14 +1,14 @@
 use na::Transform;
-use bounding_volume::{AABB, HasAABB};
+use bounding_volume::{AABB, HasBoundingVolume};
 use bounding_volume::aabb_utils;
 use shape::Convex;
 use math::Point;
 
-impl<P, M> HasAABB<P, M> for Convex<P>
+impl<P, M> HasBoundingVolume<M, AABB<P>> for Convex<P>
     where P: Point,
           M: Transform<P> {
     #[inline]
-    fn aabb(&self, m: &M) -> AABB<P> {
+    fn bounding_volume(&self, m: &M) -> AABB<P> {
         let (min, max) = aabb_utils::point_cloud_aabb(m, self.points());
 
         AABB::new(min, max)

--- a/ncollide_entities/bounding_volume/aabb_cuboid.rs
+++ b/ncollide_entities/bounding_volume/aabb_cuboid.rs
@@ -1,14 +1,14 @@
 use na::{AbsoluteRotate, Translate};
 use na;
-use bounding_volume::{HasAABB, AABB};
+use bounding_volume::{HasBoundingVolume, AABB};
 use shape::Cuboid;
 use math::Point;
 
-impl<P, M> HasAABB<P, M> for Cuboid<P::Vect>
+impl<P, M> HasBoundingVolume<M, AABB<P>> for Cuboid<P::Vect>
     where P: Point,
           M: Translate<P> + AbsoluteRotate<P::Vect> {
     #[inline]
-    fn aabb(&self, m: &M) -> AABB<P> {
+    fn bounding_volume(&self, m: &M) -> AABB<P> {
         let center          = m.translate(&na::orig());
         let ws_half_extents = m.absolute_rotate(self.half_extents());
 

--- a/ncollide_entities/bounding_volume/aabb_mesh.rs
+++ b/ncollide_entities/bounding_volume/aabb_mesh.rs
@@ -1,17 +1,17 @@
 use na::{Translate, Translation, Transform, AbsoluteRotate};
 use na;
-use bounding_volume::{AABB, HasAABB};
+use bounding_volume::{self, AABB, HasBoundingVolume};
 use shape::{BaseMesh, BaseMeshElement, TriMesh, Polyline};
 use math::{Scalar, Point, Vect};
 
 
-impl<P, M, I, E> HasAABB<P, M> for BaseMesh<P, I, E>
+impl<P, M, I, E> HasBoundingVolume<M, AABB<P>> for BaseMesh<P, I, E>
     where P: Point,
           P::Vect: Translate<P>,
           M: AbsoluteRotate<P::Vect> + Transform<P>,
           E: BaseMeshElement<I, P> {
     #[inline]
-    fn aabb(&self, m: &M) -> AABB<P> {
+    fn bounding_volume(&self, m: &M) -> AABB<P> {
         let bv              = self.bvt().root_bounding_volume().unwrap();
         let ls_center       = na::orig::<P>() + bv.translation();
         let center          = m.transform(&ls_center);
@@ -22,22 +22,22 @@ impl<P, M, I, E> HasAABB<P, M> for BaseMesh<P, I, E>
     }
 }
 
-impl<P, M> HasAABB<P, M> for TriMesh<P>
+impl<P, M> HasBoundingVolume<M, AABB<P>> for TriMesh<P>
     where P: Point,
           P::Vect: Translate<P>,
           M: AbsoluteRotate<P::Vect> + Transform<P> {
     #[inline]
-    fn aabb(&self, m: &M) -> AABB<P> {
-        self.base_mesh().aabb(m)
+    fn bounding_volume(&self, m: &M) -> AABB<P> {
+        bounding_volume::aabb(self.base_mesh(), m)
     }
 }
 
-impl<P, M> HasAABB<P, M> for Polyline<P>
+impl<P, M> HasBoundingVolume<M, AABB<P>> for Polyline<P>
     where P: Point,
           P::Vect: Translate<P>,
           M: AbsoluteRotate<P::Vect> + Transform<P> {
     #[inline]
-    fn aabb(&self, m: &M) -> AABB<P> {
-        self.base_mesh().aabb(m)
+    fn bounding_volume(&self, m: &M) -> AABB<P> {
+        bounding_volume::aabb(self.base_mesh(), m)
     }
 }

--- a/ncollide_entities/bounding_volume/aabb_plane.rs
+++ b/ncollide_entities/bounding_volume/aabb_plane.rs
@@ -1,14 +1,14 @@
 use na::Bounded;
 use na;
-use bounding_volume::{HasAABB, AABB};
+use bounding_volume::{HasBoundingVolume, AABB};
 use shape::Plane;
 use math::{Scalar, Point, Vect};
 
 
-impl<P, M> HasAABB<P, M> for Plane<P::Vect>
+impl<P, M> HasBoundingVolume<M, AABB<P>> for Plane<P::Vect>
     where P: Point {
     #[inline]
-    fn aabb(&self, _: &M) -> AABB<P> {
+    fn bounding_volume(&self, _: &M) -> AABB<P> {
         // we divide by 2.0  so that we can still make some operations with it (like loosening)
         // without breaking the box.
         let max: P = Bounded::max_value();

--- a/ncollide_entities/bounding_volume/aabb_repr.rs
+++ b/ncollide_entities/bounding_volume/aabb_repr.rs
@@ -1,53 +1,53 @@
 use na::Translate;
-use bounding_volume::{HasAABB, AABB};
+use bounding_volume::{self, HasBoundingVolume, AABB};
 use math::{Scalar, Point, Vect, Isometry};
 use shape::{Ball, Capsule, Compound, Cone, Convex, Cuboid, Cylinder, TriMesh, Polyline, Plane,
             Segment, Triangle};
 use inspection::Repr;
 
-impl<P, M> HasAABB<P, M> for Repr<P, M>
+impl<P, M> HasBoundingVolume<M, AABB<P>> for Repr<P, M>
     where P: Point,
           P::Vect: Translate<P>,
           M: Isometry<P, P::Vect> {
     #[inline]
-    fn aabb(&self, m: &M) -> AABB<P> {
+    fn bounding_volume(&self, m: &M) -> AABB<P> {
         let repr = self.repr();
 
         if let Some(b) = repr.downcast_ref::<Ball<<P::Vect as Vect>::Scalar>>() {
-            b.aabb(m)
+            bounding_volume::aabb(b, m)
         }
         else if let Some(c) = repr.downcast_ref::<Capsule<<P::Vect as Vect>::Scalar>>() {
-            c.aabb(m)
+            bounding_volume::aabb(c, m)
         }
         else if let Some(c) = repr.downcast_ref::<Compound<P, M>>() {
-            c.aabb(m)
+            bounding_volume::aabb(c, m)
         }
         else if let Some(c) = repr.downcast_ref::<Cone<<P::Vect as Vect>::Scalar>>() {
-            c.aabb(m)
+            bounding_volume::aabb(c, m)
         }
         else if let Some(c) = repr.downcast_ref::<Convex<P>>() {
-            c.aabb(m)
+            bounding_volume::aabb(c, m)
         }
         else if let Some(c) = repr.downcast_ref::<Cuboid<P::Vect>>() {
-            c.aabb(m)
+            bounding_volume::aabb(c, m)
         }
         else if let Some(c) = repr.downcast_ref::<Cylinder<<P::Vect as Vect>::Scalar>>() {
-            c.aabb(m)
+            bounding_volume::aabb(c, m)
         }
         else if let Some(t) = repr.downcast_ref::<TriMesh<P>>() {
-            t.aabb(m)
+            bounding_volume::aabb(t, m)
         }
         else if let Some(p) = repr.downcast_ref::<Polyline<P>>() {
-            p.aabb(m)
+            bounding_volume::aabb(p, m)
         }
         else if let Some(p) = repr.downcast_ref::<Plane<P::Vect>>() {
-            p.aabb(m)
+            bounding_volume::aabb(p, m)
         }
         else if let Some(s) = repr.downcast_ref::<Segment<P>>() {
-            s.aabb(m)
+            bounding_volume::aabb(s, m)
         }
         else if let Some(t) = repr.downcast_ref::<Triangle<P>>() {
-            t.aabb(m)
+            bounding_volume::aabb(t, m)
         }
         else {
             /*

--- a/ncollide_entities/bounding_volume/aabb_segment.rs
+++ b/ncollide_entities/bounding_volume/aabb_segment.rs
@@ -1,12 +1,12 @@
-use bounding_volume::{HasAABB, AABB};
+use bounding_volume::{HasBoundingVolume, AABB};
 use bounding_volume;
 use shape::Segment;
 use math::Matrix;
 use math::{Scalar, Point, Vect};
 
-impl HasAABB for Segment {
+impl HasBoundingVolume for Segment {
     #[inline]
-    fn aabb(&self, m: &Matrix) -> AABB {
+    fn bounding_volume(&self, m: &Matrix) -> AABB {
         // FIXME: optimize that
         bounding_volume::implicit_shape_aabb(m, self)
     }

--- a/ncollide_entities/bounding_volume/aabb_support_map.rs
+++ b/ncollide_entities/bounding_volume/aabb_support_map.rs
@@ -1,52 +1,52 @@
 use na::{Rotate, Transform};
-use bounding_volume::{HasAABB, AABB};
+use bounding_volume::{HasBoundingVolume, AABB};
 use bounding_volume;
 use shape::{Cone, Cylinder, Capsule};
 use shape::{Triangle, Segment};
 use math::{Scalar, Point, Vect};
 
-impl<P, M> HasAABB<P, M> for Cone<<P::Vect as Vect>::Scalar>
+impl<P, M> HasBoundingVolume<M, AABB<P>> for Cone<<P::Vect as Vect>::Scalar>
     where P: Point,
           M: Transform<P> + Rotate<P::Vect> {
     #[inline]
-    fn aabb(&self, m: &M) -> AABB<P> {
+    fn bounding_volume(&self, m: &M) -> AABB<P> {
         bounding_volume::implicit_shape_aabb(m, self)
     }
 }
 
-impl<P, M> HasAABB<P, M> for Cylinder<<P::Vect as Vect>::Scalar>
+impl<P, M> HasBoundingVolume<M, AABB<P>> for Cylinder<<P::Vect as Vect>::Scalar>
     where P: Point,
           M: Transform<P> + Rotate<P::Vect> {
     #[inline]
-    fn aabb(&self, m: &M) -> AABB<P> {
+    fn bounding_volume(&self, m: &M) -> AABB<P> {
         bounding_volume::implicit_shape_aabb(m, self)
     }
 }
 
-impl<P, M> HasAABB<P, M> for Capsule<<P::Vect as Vect>::Scalar>
+impl<P, M> HasBoundingVolume<M, AABB<P>> for Capsule<<P::Vect as Vect>::Scalar>
     where P: Point,
           M: Transform<P> + Rotate<P::Vect> {
     #[inline]
-    fn aabb(&self, m: &M) -> AABB<P> {
+    fn bounding_volume(&self, m: &M) -> AABB<P> {
         bounding_volume::implicit_shape_aabb(m, self)
     }
 }
 
-impl<P, M> HasAABB<P, M> for Triangle<P>
+impl<P, M> HasBoundingVolume<M, AABB<P>> for Triangle<P>
     where P: Point,
           M: Transform<P> + Rotate<P::Vect> {
     #[inline]
-    fn aabb(&self, m: &M) -> AABB<P> {
+    fn bounding_volume(&self, m: &M) -> AABB<P> {
         // FIXME: optimize that
         bounding_volume::implicit_shape_aabb(m, self)
     }
 }
 
-impl<P, M> HasAABB<P, M> for Segment<P>
+impl<P, M> HasBoundingVolume<M, AABB<P>> for Segment<P>
     where P: Point,
           M: Transform<P> + Rotate<P::Vect> {
     #[inline]
-    fn aabb(&self, m: &M) -> AABB<P> {
+    fn bounding_volume(&self, m: &M) -> AABB<P> {
         // FIXME: optimize that
         bounding_volume::implicit_shape_aabb(m, self)
     }

--- a/ncollide_entities/bounding_volume/aabb_triangle.rs
+++ b/ncollide_entities/bounding_volume/aabb_triangle.rs
@@ -1,12 +1,12 @@
-use bounding_volume::{HasAABB, AABB};
+use bounding_volume::{HasBoundingVolume, AABB};
 use bounding_volume;
 use shape::Triangle;
 use math::Matrix;
 use math::{Scalar, Point, Vect};
 
-impl HasAABB for Triangle {
+impl HasBoundingVolume for Triangle {
     #[inline]
-    fn aabb(&self, m: &Matrix) -> AABB {
+    fn bounding_volume(&self, m: &Matrix) -> AABB {
         // FIXME: optimize that
         bounding_volume::implicit_shape_aabb(m, self)
     }

--- a/ncollide_entities/bounding_volume/bounding_sphere.rs
+++ b/ncollide_entities/bounding_volume/bounding_sphere.rs
@@ -3,22 +3,16 @@
 use na::{Translation, Norm, Transform, Translate};
 use na;
 use math::{Scalar, Point, Vect};
-use bounding_volume::BoundingVolume;
-
-/// Trait implemented by objects having a bounding sphere.
-pub trait HasBoundingSphere<P, M> {
-    /// The object bounding sphere.
-    fn bounding_sphere(&self, m: &M) -> BoundingSphere<P>;
-}
+use bounding_volume::{BoundingVolume, HasBoundingVolume};
 
 // Seems useful to help type inference. See issue #84.
 /// Computes the bounding sphere of a shape `g` transformed by `m`.
 ///
 /// Same as `g.bounding_sphere(m)`.
-pub fn bounding_sphere<P, M, G>(g: &G, m: &M) -> BoundingSphere<P>
+pub fn bounding_sphere<P, M, G: ?Sized>(g: &G, m: &M) -> BoundingSphere<P>
     where P: Point,
-          G: HasBoundingSphere<P, M> {
-    g.bounding_sphere(m)
+          G: HasBoundingVolume<M, BoundingSphere<P>> {
+    g.bounding_volume(m)
 }
 
 /// A Bounding Sphere.

--- a/ncollide_entities/bounding_volume/bounding_sphere_ball.rs
+++ b/ncollide_entities/bounding_volume/bounding_sphere_ball.rs
@@ -1,15 +1,15 @@
 use na::Translate;
 use na;
-use bounding_volume::{HasBoundingSphere, BoundingSphere};
+use bounding_volume::{HasBoundingVolume, BoundingSphere};
 use shape::Ball;
 use math::{Scalar, Point, Vect};
 
 
-impl<P, M> HasBoundingSphere<P, M> for Ball<<P::Vect as Vect>::Scalar>
+impl<P, M> HasBoundingVolume<M, BoundingSphere<P>> for Ball<<P::Vect as Vect>::Scalar>
     where P: Point,
           M: Translate<P> {
     #[inline]
-    fn bounding_sphere(&self, m: &M) -> BoundingSphere<P> {
+    fn bounding_volume(&self, m: &M) -> BoundingSphere<P> {
         let center = m.translate(&na::orig());
         let radius = self.radius();
 

--- a/ncollide_entities/bounding_volume/bounding_sphere_capsule.rs
+++ b/ncollide_entities/bounding_volume/bounding_sphere_capsule.rs
@@ -1,15 +1,15 @@
 use na::Translate;
 use na;
-use bounding_volume::{HasBoundingSphere, BoundingSphere};
+use bounding_volume::{HasBoundingVolume, BoundingSphere};
 use shape::Capsule;
 use math::{Scalar, Point, Vect};
 
 
-impl<P, M> HasBoundingSphere<P, M> for Capsule<<P::Vect as Vect>::Scalar>
+impl<P, M> HasBoundingVolume<M, BoundingSphere<P>> for Capsule<<P::Vect as Vect>::Scalar>
     where P: Point,
           M: Translate<P> {
     #[inline]
-    fn bounding_sphere(&self, m: &M) -> BoundingSphere<P> {
+    fn bounding_volume(&self, m: &M) -> BoundingSphere<P> {
         let center = m.translate(&na::orig());
         let radius = self.radius() + self.half_height();
 

--- a/ncollide_entities/bounding_volume/bounding_sphere_compound.rs
+++ b/ncollide_entities/bounding_volume/bounding_sphere_compound.rs
@@ -1,22 +1,22 @@
 use na::{Transform, Translate};
-use bounding_volume::{BoundingVolume, BoundingSphere, HasBoundingSphere};
+use bounding_volume::{self, BoundingVolume, BoundingSphere, HasBoundingVolume};
 use shape::Compound;
 use math::{Point, Vect, Isometry};
 
 
-impl<P, M, M2> HasBoundingSphere<P, M2> for Compound<P, M>
+impl<P, M, M2> HasBoundingVolume<M2, BoundingSphere<P>> for Compound<P, M>
     where P:  Point,
           P::Vect: Translate<P>,
           M:  Isometry<P, P::Vect>,
           M2: Transform<P> + Translate<P> {
     #[inline]
-    fn bounding_sphere(&self, m: &M2) -> BoundingSphere<P> {
+    fn bounding_volume(&self, m: &M2) -> BoundingSphere<P> {
         let shapes = self.shapes();
 
-        let mut res = shapes[0].1.bounding_sphere(&shapes[0].0);
+        let mut res = bounding_volume::bounding_sphere(&**shapes[0].1, &shapes[0].0);
 
         for &(ref t, ref s) in shapes[1 ..].iter() {
-            res.merge(&s.bounding_sphere(t));
+            res.merge(&bounding_volume::bounding_sphere(&***s, t));
         }
 
         BoundingSphere::new(m.transform(res.center()), res.radius())

--- a/ncollide_entities/bounding_volume/bounding_sphere_cone.rs
+++ b/ncollide_entities/bounding_volume/bounding_sphere_cone.rs
@@ -1,16 +1,16 @@
 use num::Float;
 use na::{Translate};
 use na;
-use bounding_volume::{HasBoundingSphere, BoundingSphere};
+use bounding_volume::{HasBoundingVolume, BoundingSphere};
 use shape::Cone;
 use math::{Scalar, Point, Vect};
 
 
-impl<P, M> HasBoundingSphere<P, M> for Cone<<P::Vect as Vect>::Scalar>
+impl<P, M> HasBoundingVolume<M, BoundingSphere<P>> for Cone<<P::Vect as Vect>::Scalar>
     where P: Point,
           M: Translate<P> {
     #[inline]
-    fn bounding_sphere(&self, m: &M) -> BoundingSphere<P> {
+    fn bounding_volume(&self, m: &M) -> BoundingSphere<P> {
         let center = m.translate(&na::orig());
         let radius = (self.radius() * self.radius() + self.half_height() * self.half_height()).sqrt();
 

--- a/ncollide_entities/bounding_volume/bounding_sphere_convex.rs
+++ b/ncollide_entities/bounding_volume/bounding_sphere_convex.rs
@@ -1,15 +1,15 @@
 use na::Transform;
-use bounding_volume::{BoundingSphere, HasBoundingSphere};
+use bounding_volume::{BoundingSphere, HasBoundingVolume};
 use bounding_volume;
 use shape::Convex;
 use math::Point;
 
 
-impl<P, M> HasBoundingSphere<P, M> for Convex<P>
+impl<P, M> HasBoundingVolume<M, BoundingSphere<P>> for Convex<P>
     where P: Point,
           M: Transform<P> {
     #[inline]
-    fn bounding_sphere(&self, m: &M) -> BoundingSphere<P> {
+    fn bounding_volume(&self, m: &M) -> BoundingSphere<P> {
         let (center, radius) = bounding_volume::point_cloud_bounding_sphere(self.points());
 
         BoundingSphere::new(m.transform(&center), radius)

--- a/ncollide_entities/bounding_volume/bounding_sphere_cuboid.rs
+++ b/ncollide_entities/bounding_volume/bounding_sphere_cuboid.rs
@@ -1,16 +1,16 @@
 use na::Translate;
 use na;
-use bounding_volume::{HasBoundingSphere, BoundingSphere};
+use bounding_volume::{HasBoundingVolume, BoundingSphere};
 use shape::Cuboid;
 use math::{Point, Vect};
 
 
 
-impl<P, M> HasBoundingSphere<P, M> for Cuboid<P::Vect>
+impl<P, M> HasBoundingVolume<M, BoundingSphere<P>> for Cuboid<P::Vect>
     where P: Point,
           M: Translate<P> {
     #[inline]
-    fn bounding_sphere(&self, m: &M) -> BoundingSphere<P> {
+    fn bounding_volume(&self, m: &M) -> BoundingSphere<P> {
         let center = m.translate(&na::orig::<P>());
         let radius = na::norm(self.half_extents());
 

--- a/ncollide_entities/bounding_volume/bounding_sphere_cylinder.rs
+++ b/ncollide_entities/bounding_volume/bounding_sphere_cylinder.rs
@@ -1,16 +1,16 @@
 use num::Float;
 use na::{Translate};
 use na;
-use bounding_volume::{HasBoundingSphere, BoundingSphere};
+use bounding_volume::{HasBoundingVolume, BoundingSphere};
 use shape::Cylinder;
 use math::{Scalar, Point, Vect};
 
 
-impl<P, M> HasBoundingSphere<P, M> for Cylinder<<P::Vect as Vect>::Scalar>
+impl<P, M> HasBoundingVolume<M, BoundingSphere<P>> for Cylinder<<P::Vect as Vect>::Scalar>
     where P: Point,
           M: Translate<P> {
     #[inline]
-    fn bounding_sphere(&self, m: &M) -> BoundingSphere<P> {
+    fn bounding_volume(&self, m: &M) -> BoundingSphere<P> {
         let center = m.translate(&na::orig());
         let radius = (self.radius() * self.radius() + self.half_height() * self.half_height()).sqrt();
 

--- a/ncollide_entities/bounding_volume/bounding_sphere_mesh.rs
+++ b/ncollide_entities/bounding_volume/bounding_sphere_mesh.rs
@@ -1,36 +1,36 @@
 use na::Transform;
-use bounding_volume::{BoundingSphere, HasBoundingSphere};
+use bounding_volume::{BoundingSphere, HasBoundingVolume};
 use bounding_volume;
 use shape::{BaseMesh, BaseMeshElement, TriMesh, Polyline};
 use math::Point;
 
 
-impl<P, M, I, E> HasBoundingSphere<P, M> for BaseMesh<P, I, E>
+impl<P, M, I, E> HasBoundingVolume<M, BoundingSphere<P>> for BaseMesh<P, I, E>
     where P: Point,
           M: Transform<P>,
           E: BaseMeshElement<I, P> {
     #[inline]
-    fn bounding_sphere(&self, m: &M) -> BoundingSphere<P> {
+    fn bounding_volume(&self, m: &M) -> BoundingSphere<P> {
         let (center, radius) = bounding_volume::point_cloud_bounding_sphere(&self.vertices()[..]);
 
         BoundingSphere::new(m.transform(&center), radius)
     }
 }
 
-impl<P, M> HasBoundingSphere<P, M> for TriMesh<P>
+impl<P, M> HasBoundingVolume<M, BoundingSphere<P>> for TriMesh<P>
     where P: Point,
           M: Transform<P> {
     #[inline]
-    fn bounding_sphere(&self, m: &M) -> BoundingSphere<P> {
-        self.base_mesh().bounding_sphere(m)
+    fn bounding_volume(&self, m: &M) -> BoundingSphere<P> {
+        self.base_mesh().bounding_volume(m)
     }
 }
 
-impl<P, M> HasBoundingSphere<P, M> for Polyline<P>
+impl<P, M> HasBoundingVolume<M, BoundingSphere<P>> for Polyline<P>
     where P: Point,
           M: Transform<P> {
     #[inline]
-    fn bounding_sphere(&self, m: &M) -> BoundingSphere<P> {
-        self.base_mesh().bounding_sphere(m)
+    fn bounding_volume(&self, m: &M) -> BoundingSphere<P> {
+        self.base_mesh().bounding_volume(m)
     }
 }

--- a/ncollide_entities/bounding_volume/bounding_sphere_plane.rs
+++ b/ncollide_entities/bounding_volume/bounding_sphere_plane.rs
@@ -1,14 +1,14 @@
 use na::Bounded;
 use na;
-use bounding_volume::{HasBoundingSphere, BoundingSphere};
+use bounding_volume::{HasBoundingVolume, BoundingSphere};
 use shape::Plane;
 use math::{Point, Vect};
 
 
-impl<P, M> HasBoundingSphere<P, M> for Plane<P::Vect>
+impl<P, M> HasBoundingVolume<M, BoundingSphere<P>> for Plane<P::Vect>
     where P: Point {
     #[inline]
-    fn bounding_sphere(&self, _: &M) -> BoundingSphere<P> {
+    fn bounding_volume(&self, _: &M) -> BoundingSphere<P> {
         let center = na::orig();
         let radius = Bounded::max_value(); // FIXME: is this a good idea?
 

--- a/ncollide_entities/bounding_volume/bounding_sphere_repr.rs
+++ b/ncollide_entities/bounding_volume/bounding_sphere_repr.rs
@@ -1,54 +1,54 @@
 use na::Translate;
-use bounding_volume::{HasBoundingSphere, BoundingSphere};
+use bounding_volume::{HasBoundingVolume, BoundingSphere};
 use math::{Scalar, Point, Vect, Isometry};
 use shape::{Ball, Capsule, Compound, Cone, Convex, Cuboid, Cylinder, TriMesh, Polyline, Plane,
             Segment, Triangle};
 use inspection::Repr;
 
 
-impl<P, M> HasBoundingSphere<P, M> for Repr<P, M>
+impl<P, M> HasBoundingVolume<M, BoundingSphere<P>> for Repr<P, M>
     where P: Point,
           P::Vect: Translate<P>,
           M: Isometry<P, P::Vect> {
     #[inline]
-    fn bounding_sphere(&self, m: &M) -> BoundingSphere<P> {
+    fn bounding_volume(&self, m: &M) -> BoundingSphere<P> {
         let repr = self.repr();
 
         if let Some(b) = repr.downcast_ref::<Ball<<P::Vect as Vect>::Scalar>>() {
-            b.bounding_sphere(m)
+            b.bounding_volume(m)
         }
         else if let Some(c) = repr.downcast_ref::<Capsule<<P::Vect as Vect>::Scalar>>() {
-            c.bounding_sphere(m)
+            c.bounding_volume(m)
         }
         else if let Some(c) = repr.downcast_ref::<Compound<P, M>>() {
-            c.bounding_sphere(m)
+            c.bounding_volume(m)
         }
         else if let Some(c) = repr.downcast_ref::<Cone<<P::Vect as Vect>::Scalar>>() {
-            c.bounding_sphere(m)
+            c.bounding_volume(m)
         }
         else if let Some(c) = repr.downcast_ref::<Convex<P>>() {
-            c.bounding_sphere(m)
+            c.bounding_volume(m)
         }
         else if let Some(c) = repr.downcast_ref::<Cuboid<P::Vect>>() {
-            c.bounding_sphere(m)
+            c.bounding_volume(m)
         }
         else if let Some(c) = repr.downcast_ref::<Cylinder<<P::Vect as Vect>::Scalar>>() {
-            c.bounding_sphere(m)
+            c.bounding_volume(m)
         }
         else if let Some(t) = repr.downcast_ref::<TriMesh<P>>() {
-            t.bounding_sphere(m)
+            t.bounding_volume(m)
         }
         else if let Some(p) = repr.downcast_ref::<Polyline<P>>() {
-            p.bounding_sphere(m)
+            p.bounding_volume(m)
         }
         else if let Some(p) = repr.downcast_ref::<Plane<P::Vect>>() {
-            p.bounding_sphere(m)
+            p.bounding_volume(m)
         }
         else if let Some(s) = repr.downcast_ref::<Segment<P>>() {
-            s.bounding_sphere(m)
+            s.bounding_volume(m)
         }
         else if let Some(t) = repr.downcast_ref::<Triangle<P>>() {
-            t.bounding_sphere(m)
+            t.bounding_volume(m)
         }
         else {
             /*

--- a/ncollide_entities/bounding_volume/bounding_sphere_segment.rs
+++ b/ncollide_entities/bounding_volume/bounding_sphere_segment.rs
@@ -1,15 +1,15 @@
 use na::Transform;
-use bounding_volume::{BoundingSphere, HasBoundingSphere};
+use bounding_volume::{BoundingSphere, HasBoundingVolume};
 use bounding_volume;
 use shape::Segment;
 use math::Point;
 
 
-impl<P, M> HasBoundingSphere<P, M> for Segment<P>
+impl<P, M> HasBoundingVolume<M, BoundingSphere<P>> for Segment<P>
     where P: Point,
           M: Transform<P> {
     #[inline]
-    fn bounding_sphere(&self, m: &M) -> BoundingSphere<P> {
+    fn bounding_volume(&self, m: &M) -> BoundingSphere<P> {
         let pts = [ self.a().clone(), self.b().clone() ];
         let (center, radius) = bounding_volume::point_cloud_bounding_sphere(&pts[..]);
 

--- a/ncollide_entities/bounding_volume/bounding_sphere_triangle.rs
+++ b/ncollide_entities/bounding_volume/bounding_sphere_triangle.rs
@@ -1,15 +1,15 @@
 use na::Transform;
-use bounding_volume::{BoundingSphere, HasBoundingSphere};
+use bounding_volume::{BoundingSphere, HasBoundingVolume};
 use bounding_volume;
 use shape::Triangle;
 use math::Point;
 
 
-impl<P, M> HasBoundingSphere<P, M> for Triangle<P>
+impl<P, M> HasBoundingVolume<M, BoundingSphere<P>> for Triangle<P>
     where P: Point,
           M: Transform<P> {
     #[inline]
-    fn bounding_sphere(&self, m: &M) -> BoundingSphere<P> {
+    fn bounding_volume(&self, m: &M) -> BoundingSphere<P> {
         let pts = [ self.a().clone(), self.b().clone(), self.c().clone() ];
         let (center, radius) = bounding_volume::point_cloud_bounding_sphere(&pts[..]);
 

--- a/ncollide_entities/bounding_volume/bounding_volume.rs
+++ b/ncollide_entities/bounding_volume/bounding_volume.rs
@@ -1,7 +1,7 @@
 /// Traits of objects having a bounding volume.
-pub trait HasBoundingVolume<BV> {
-    /// The object bounding volume.
-    fn bounding_volume(&self) -> BV;
+pub trait HasBoundingVolume<M, BV> {
+    /// The bounding volume of `self` transformed by `m`.
+    fn bounding_volume(&self, m: &M) -> BV;
 }
 
 /// Trait of bounding volumes.

--- a/ncollide_entities/bounding_volume/mod.rs
+++ b/ncollide_entities/bounding_volume/mod.rs
@@ -3,9 +3,9 @@
 #[doc(inline)]
 pub use bounding_volume::bounding_volume::{HasBoundingVolume, BoundingVolume};
 #[doc(inline)]
-pub use bounding_volume::aabb::{HasAABB, AABB, aabb};
+pub use bounding_volume::aabb::{AABB, aabb};
 #[doc(inline)]
-pub use bounding_volume::bounding_sphere::{HasBoundingSphere, BoundingSphere, bounding_sphere};
+pub use bounding_volume::bounding_sphere::{BoundingSphere, bounding_sphere};
 
 pub use bounding_volume::aabb_utils::{implicit_shape_aabb, point_cloud_aabb};
 pub use bounding_volume::aabb_ball::ball_aabb;

--- a/ncollide_entities/partitioning/bvt.rs
+++ b/ncollide_entities/partitioning/bvt.rs
@@ -53,7 +53,10 @@ impl<B, BV> BVT<B, BV> {
         }
     }
 
-    /// Visit this tree using… a visitor!
+    /// Traverses this tree using an object implementing the `BVTVisitor`trait.
+    ///
+    /// This will traverse the whole tree and call the visitor `.visit_internal(...)` (resp.
+    /// `.visit_leaf(...)`) method on each internal (resp. leaf) node.
     pub fn visit<Vis: BVTVisitor<B, BV>>(&self, visitor: &mut Vis) {
         match self.tree {
             Some(ref t) => t.visit(visitor),

--- a/ncollide_entities/partitioning/dbvt.rs
+++ b/ncollide_entities/partitioning/dbvt.rs
@@ -78,7 +78,10 @@ impl<P, B, BV> DBVT<P, B, BV>
         self.len = self.len + 1;
     }
 
-    /// Visit this tree using… a visitor!
+    /// Traverses this tree using an object implementing the `BVTVisitor`trait.
+    ///
+    /// This will traverse the whole tree and call the visitor `.visit_internal(...)` (resp.
+    /// `.visit_leaf(...)`) method on each internal (resp. leaf) node.
     pub fn visit<Vis: BVTVisitor<B, BV>>(&self, visitor: &mut Vis) {
         match self.tree {
             Some(ref t) => t.visit(visitor),

--- a/ncollide_entities/shape/base_mesh.rs
+++ b/ncollide_entities/shape/base_mesh.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::marker::PhantomData;
 use na::{Translate, Identity, Pnt2};
 use partitioning::BVT;
-use bounding_volume::{HasAABB, AABB};
+use bounding_volume::{self, HasBoundingVolume, AABB};
 use math::{Scalar, Point, Vect};
 
 
@@ -43,7 +43,7 @@ impl<P, I, E> Clone for BaseMesh<P, I, E>
 impl<P, I, E> BaseMesh<P, I, E>
     where P: Point,
           P::Vect: Translate<P>,
-          E: BaseMeshElement<I, P> + HasAABB<P, Identity> {
+          E: BaseMeshElement<I, P> + HasBoundingVolume<Identity, AABB<P>> {
     /// Builds a new mesh.
     pub fn new(vertices: Arc<Vec<P>>,
                indices:  Arc<Vec<I>>,
@@ -65,7 +65,7 @@ impl<P, I, E> BaseMesh<P, I, E>
                 let vs: &[P] = &vs[..];
                 let element: E = BaseMeshElement::new_with_vertices_and_indices(vs, is);
                 // loosen for better persistancy
-                let bv = element.aabb(&Identity::new());
+                let bv = bounding_volume::aabb(&element, &Identity::new());
                 leaves.push((i, bv.clone()));
                 bvs.push(bv);
             }

--- a/ncollide_entities/shape/compound.rs
+++ b/ncollide_entities/shape/compound.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 use na::Translate;
 use na;
-use bounding_volume::{HasAABB, AABB, BoundingVolume};
+use bounding_volume::{self, AABB, BoundingVolume};
 use partitioning::BVT;
 use math::{Point, Vect, Isometry};
 use inspection::Repr;
@@ -44,7 +44,7 @@ impl<P, M> Compound<P, M>
 
         for (i, &(ref delta, ref shape)) in shapes.iter().enumerate() {
             // loosen for better persistancy
-            let bv = shape.aabb(delta).loosened(na::cast(0.04f64));
+            let bv = bounding_volume::aabb(&***shape, delta).loosened(na::cast(0.04f64));
 
             bvs.push(bv.clone());
             leaves.push((i, bv));

--- a/ncollide_pipeline/Cargo.toml
+++ b/ncollide_pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ncollide_pipeline"
-version = "0.2.3"
+version = "0.3.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 and 3-dimensional collision detection library in Rust: module describing the collision detection pipeline (broad phase/narrow phase) of ncollide."

--- a/ncollide_pipeline/broad_phase/dbvt_broad_phase.rs
+++ b/ncollide_pipeline/broad_phase/dbvt_broad_phase.rs
@@ -6,7 +6,7 @@ use utils::data::uid_remap::{UidRemap, FastKey};
 use utils::data::pair::{Pair, PairTWHash};
 use utils::data::hash_map::HashMap;
 use math::{Scalar, Point, Vect};
-use entities::bounding_volume::{HasBoundingVolume, BoundingVolume, BoundingVolumeInterferencesCollector};
+use entities::bounding_volume::{BoundingVolume, BoundingVolumeInterferencesCollector};
 use entities::partitioning::{DBVT, DBVTLeaf};
 use queries::ray::{Ray, RayCast, RayInterferencesCollector};
 use queries::point::{PointQuery, PointInterferencesCollector};

--- a/ncollide_pipeline/narrow_phase/composite_shape_repr.rs
+++ b/ncollide_pipeline/narrow_phase/composite_shape_repr.rs
@@ -3,7 +3,7 @@ use na::Translate;
 use math::{Scalar, Point, Vect, Isometry};
 use utils::data::hash_map::HashMap;
 use utils::data::hash::UintTWHash;
-use entities::bounding_volume::{HasAABB, BoundingVolume};
+use entities::bounding_volume::{self, BoundingVolume};
 use entities::partitioning::BoundingVolumeInterferencesCollector;
 use entities::shape::CompositeShape;
 use entities::inspection::Repr;
@@ -45,7 +45,7 @@ impl<P, M> CompositeShapeRepr<P, M>
                  swap:       bool) {
         // Find new collisions
         let ls_m2    = na::inv(m1).expect("The transformation `m1` must be inversible.") * *m2;
-        let ls_aabb2 = g2.aabb(&ls_m2).loosened(self.prediction);
+        let ls_aabb2 = bounding_volume::aabb(g2, &ls_m2).loosened(self.prediction);
 
         {
             let mut visitor = BoundingVolumeInterferencesCollector::new(&ls_aabb2, &mut self.interferences);

--- a/ncollide_queries/Cargo.toml
+++ b/ncollide_queries/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ncollide_queries"
-version = "0.2.5"
+version = "0.3.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 and 3-dimensional collision detection library in Rust: module for geometric queries like distances computation, ray casting and contact determination."

--- a/ncollide_queries/geometry/contacts_internal/any_against_any.rs
+++ b/ncollide_queries/geometry/contacts_internal/any_against_any.rs
@@ -4,7 +4,7 @@ use math::{Scalar, Point, Vect, Isometry};
 use entities::inspection;
 use entities::inspection::Repr;
 use entities::shape::{Ball, Plane};
-use entities::bounding_volume::HasAABB;
+use entities::bounding_volume::{HasBoundingVolume, AABB};
 use geometry::contacts_internal;
 use geometry::contacts_internal::Contact;
 
@@ -18,8 +18,8 @@ pub fn any_against_any<P, M, G1: ?Sized, G2: ?Sized>(m1: &M, g1: &G1,
     where P:  Point,
           P::Vect: Translate<P>,
           M:  Isometry<P, P::Vect> + Translation<P::Vect>,
-          G1: Repr<P, M> + HasAABB<P, M>,
-          G2: Repr<P, M> + HasAABB<P, M> {
+          G1: Repr<P, M> + HasBoundingVolume<M, AABB<P>>,
+          G2: Repr<P, M> + HasBoundingVolume<M, AABB<P>> {
     let r1 = g1.repr();
     let r2 = g2.repr();
 

--- a/ncollide_queries/geometry/contacts_internal/composite_shape_against_any.rs
+++ b/ncollide_queries/geometry/contacts_internal/composite_shape_against_any.rs
@@ -1,7 +1,7 @@
 use na::{Translate, Translation};
 use na;
 use entities::partitioning::BoundingVolumeInterferencesCollector;
-use entities::bounding_volume::{BoundingVolume, HasAABB};
+use entities::bounding_volume::{self, BoundingVolume, HasBoundingVolume, AABB};
 use entities::inspection::Repr;
 use entities::shape::CompositeShape;
 use geometry::Contact;
@@ -74,10 +74,10 @@ pub fn composite_shape_against_any<P, M, G1: ?Sized, G2: ?Sized>(
           P::Vect: Translate<P>,
           M:  Isometry<P, P::Vect> + Translation<P::Vect>,
           G1: CompositeShape<P, M>,
-          G2: Repr<P, M> + HasAABB<P, M> {
+          G2: Repr<P, M> + HasBoundingVolume<M, AABB<P>> {
     // Find new collisions
     let ls_m2    = na::inv(m1).expect("The transformation `m1` must be inversible.") * *m2;
-    let ls_aabb2 = g2.aabb(&ls_m2).loosened(prediction);
+    let ls_aabb2 = bounding_volume::aabb(g2, &ls_m2).loosened(prediction);
 
     let mut interferences = Vec::new();
 
@@ -120,7 +120,7 @@ pub fn any_against_composite_shape<P, M, G1: ?Sized, G2: ?Sized>(
     where P:  Point,
           P::Vect: Translate<P>,
           M:  Isometry<P, P::Vect> + Translation<P::Vect>,
-          G1: Repr<P, M> + HasAABB<P, M>,
+          G1: Repr<P, M> + HasBoundingVolume<M, AABB<P>>,
           G2: CompositeShape<P, M> {
     let mut res = composite_shape_against_any(m2, g2, m1, g1, prediction);
 

--- a/ncollide_queries/geometry/distance_internal/any_against_any.rs
+++ b/ncollide_queries/geometry/distance_internal/any_against_any.rs
@@ -4,7 +4,7 @@ use math::{Scalar, Point, Vect, Isometry};
 use entities::inspection;
 use entities::inspection::Repr;
 use entities::shape::{Ball, Plane};
-use entities::bounding_volume::HasAABB;
+use entities::bounding_volume::{HasBoundingVolume, AABB};
 use geometry::distance_internal;
 
 /// Computes the minimum distance separating two shapes.
@@ -14,8 +14,8 @@ pub fn any_against_any<P, M, G1: ?Sized, G2: ?Sized>(m1: &M, g1: &G1, m2: &M, g2
     where P:  Point,
           P::Vect: Translate<P>,
           M:  Isometry<P, P::Vect> + Translation<P::Vect>,
-          G1: Repr<P, M> + HasAABB<P, M>,
-          G2: Repr<P, M> + HasAABB<P, M> {
+          G1: Repr<P, M> + HasBoundingVolume<M, AABB<P>>,
+          G2: Repr<P, M> + HasBoundingVolume<M, AABB<P>> {
     let r1 = g1.repr();
     let r2 = g2.repr();
 

--- a/ncollide_queries/geometry/time_of_impact_internal/any_against_any.rs
+++ b/ncollide_queries/geometry/time_of_impact_internal/any_against_any.rs
@@ -4,7 +4,7 @@ use math::{Scalar, Point, Vect, Isometry};
 use entities::inspection;
 use entities::inspection::Repr;
 use entities::shape::{Ball, Plane};
-use entities::bounding_volume::HasAABB;
+use entities::bounding_volume::{HasBoundingVolume, AABB};
 use geometry::time_of_impact_internal;
 
 /// Computes the smallest time of impact of two shapes under translational movement.
@@ -16,8 +16,8 @@ pub fn any_against_any<P, M, G1: ?Sized, G2: ?Sized>(m1: &M, vel1: &P::Vect, g1:
     where P:  Point,
           P::Vect: Translate<P>,
           M:  Isometry<P, P::Vect>,
-          G1: Repr<P, M> + HasAABB<P, M>,
-          G2: Repr<P, M> + HasAABB<P, M> {
+          G1: Repr<P, M> + HasBoundingVolume<M, AABB<P>>,
+          G2: Repr<P, M> + HasBoundingVolume<M, AABB<P>> {
     let r1 = g1.repr();
     let r2 = g2.repr();
 


### PR DESCRIPTION
They were here only because we could not implement the same trait `HasBoundingVolume<...>` twice but with different type parameters for a single type. Now that this is allowed, the `HasAABB<P, M>` and `HasBoundingSphere<P, M>` traits are removed in favor of `HasBoundingVolume<M, AABB<P>>` and `HasBoundingVolume<M, BoundingSphere<P>>` instead. The two free functions `bounding_volume::aabb(...)` and `bounding_volume::bounding_sphere(...)` still exist and are the simplest way to retrieve the bounding volume we want (without hitting some potential type inference related errors).