### PR TITLE
Fix for issue #57

### DIFF
--- a/ncollide_pipeline/tests/collision_world.rs
+++ b/ncollide_pipeline/tests/collision_world.rs
@@ -1,0 +1,37 @@
+extern crate ncollide_pipeline;
+extern crate ncollide_entities;
+extern crate nalgebra;
+
+use ncollide_pipeline::world::{CollisionGroups, CollisionWorld, CollisionWorld2};
+use ncollide_entities::shape::Ball;
+use ncollide_entities::inspection::Repr2;
+use nalgebra::{Vec1, Vec2, Iso2};
+use std::sync::Arc;
+
+type ObjectCollisionWorld = CollisionWorld2<f64, ()>;
+type ShapeRepr = Repr2<f64>;
+
+
+#[test]
+fn issue_57_object_remove() {
+	let mut world: ObjectCollisionWorld = CollisionWorld::new(0.1, 0.1, false);
+    let shape = Arc::new(Box::new(Ball::new(1.0)) as Box<ShapeRepr>);
+    world.add(0,
+              Iso2::new(Vec2::new(1.0, 0.0), Vec1::new(0.0)),
+              shape.clone(),
+              CollisionGroups::new(),
+              ());
+   world.add(1,
+              Iso2::new(Vec2::new(1.0, 1.0), Vec1::new(0.0)),
+              shape.clone(),
+              CollisionGroups::new(),
+              ());
+	world.add(2,
+              Iso2::new(Vec2::new(1.0, 2.0), Vec1::new(0.0)),
+              shape.clone(),
+              CollisionGroups::new(),
+              ());
+    world.update();
+    world.remove(0);
+    world.update();
+}


### PR DESCRIPTION
The problem described in issue #57 occurs because the object is removed on the remove() call then is not present during the update() call. This is because the narrow phase attempts to resolve colliding objects through the use of the ContactSignal. However, because the object was previously removed, one object in the pair in the callback handler is essentially null. The solution I made was to store a list of objects that are to be removed, but not actually do the removing until the end of update().

Basically, mark the object to be removed (but not remove) in remove(), then after update() remove all that have been marked.