### PR TITLE
Handle object removal properly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ncollide"
-version = "0.5.0"
+version = "0.6.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 and 3-dimensional collision detection library in Rust."

--- a/examples/dbvt_broad_phase2d.rs
+++ b/examples/dbvt_broad_phase2d.rs
@@ -27,10 +27,10 @@ fn main() {
     // First parameter:  a unique id for each object.
     // Second parameter: the object bounding box.
     // Third parameter:  some data (here, the id that identify each object).
-    bf.defered_add(0, bounding_volume::aabb(&ball, &poss[0]), 0);
-    bf.defered_add(1, bounding_volume::aabb(&ball, &poss[1]), 1);
-    bf.defered_add(2, bounding_volume::aabb(&ball, &poss[2]), 2);
-    bf.defered_add(3, bounding_volume::aabb(&ball, &poss[3]), 3);
+    bf.deferred_add(0, bounding_volume::aabb(&ball, &poss[0]), 0);
+    bf.deferred_add(1, bounding_volume::aabb(&ball, &poss[1]), 1);
+    bf.deferred_add(2, bounding_volume::aabb(&ball, &poss[2]), 2);
+    bf.deferred_add(3, bounding_volume::aabb(&ball, &poss[3]), 3);
 
     // Update the broad phase.
     // The collision filter (first closure) prevents self-collision.
@@ -39,8 +39,8 @@ fn main() {
     assert!(bf.num_interferences() == 6);
 
     // Remove two objects.
-    bf.defered_remove(0);
-    bf.defered_remove(1);
+    bf.deferred_remove(0);
+    bf.deferred_remove(1);
 
     // Update the broad phase.
     // The collision filter (first closure) prevents self-collision.

--- a/examples/dbvt_broad_phase3d.rs
+++ b/examples/dbvt_broad_phase3d.rs
@@ -27,10 +27,10 @@ fn main() {
     // First parameter:  a unique id for each object.
     // Second parameter: the object bounding box.
     // Third parameter:  some data (here, the id that identify each object).
-    bf.defered_add(0, bounding_volume::aabb(&ball, &poss[0]), 0);
-    bf.defered_add(1, bounding_volume::aabb(&ball, &poss[1]), 1);
-    bf.defered_add(2, bounding_volume::aabb(&ball, &poss[2]), 2);
-    bf.defered_add(3, bounding_volume::aabb(&ball, &poss[3]), 3);
+    bf.deferred_add(0, bounding_volume::aabb(&ball, &poss[0]), 0);
+    bf.deferred_add(1, bounding_volume::aabb(&ball, &poss[1]), 1);
+    bf.deferred_add(2, bounding_volume::aabb(&ball, &poss[2]), 2);
+    bf.deferred_add(3, bounding_volume::aabb(&ball, &poss[3]), 3);
 
     // Update the broad phase.
     // The collision filter (first closure) prevents self-collision.
@@ -39,8 +39,8 @@ fn main() {
     assert!(bf.num_interferences() == 6);
 
     // Remove two objects.
-    bf.defered_remove(0);
-    bf.defered_remove(1);
+    bf.deferred_remove(0);
+    bf.deferred_remove(1);
 
     // Update the broad phase.
     // The collision filter (first closure) prevents self-collision.

--- a/ncollide_pipeline/Cargo.toml
+++ b/ncollide_pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ncollide_pipeline"
-version = "0.4.0"
+version = "0.5.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 and 3-dimensional collision detection library in Rust: module describing the collision detection pipeline (broad phase/narrow phase) of ncollide."

--- a/ncollide_pipeline/broad_phase/broad_phase.rs
+++ b/ncollide_pipeline/broad_phase/broad_phase.rs
@@ -4,13 +4,13 @@ use math::Point;
 /// Trait all broad phase must implement.
 pub trait BroadPhase<P: Point, BV, T> {
     /// Tells the broad phase to add an element during the next update.
-    fn defered_add(&mut self, uid: usize, bv: BV, data: T);
+    fn deferred_add(&mut self, uid: usize, bv: BV, data: T);
 
     /// Tells the broad phase to remove an element during the next update.
-    fn defered_remove(&mut self, uid: usize);
+    fn deferred_remove(&mut self, uid: usize);
 
     /// Sets the next bounding volume to be used during the update of this broad phase.
-    fn defered_set_bounding_volume(&mut self, uid: usize, bv: BV);
+    fn deferred_set_bounding_volume(&mut self, uid: usize, bv: BV);
 
     /// Updates the object additions, removals, and interferences detection.
     fn update(&mut self, allow_proximity: &mut FnMut(&T, &T) -> bool, proximity_handler: &mut FnMut(&T, &T, bool));

--- a/ncollide_pipeline/tests/collision_world.rs
+++ b/ncollide_pipeline/tests/collision_world.rs
@@ -1,0 +1,37 @@
+extern crate ncollide_pipeline;
+extern crate ncollide_entities;
+extern crate nalgebra;
+
+use ncollide_pipeline::world::{CollisionGroups, CollisionWorld, CollisionWorld2};
+use ncollide_entities::shape::Ball;
+use ncollide_entities::inspection::Repr2;
+use nalgebra::{Vec1, Vec2, Iso2};
+use std::sync::Arc;
+
+type ObjectCollisionWorld = CollisionWorld2<f64, ()>;
+type ShapeRepr = Repr2<f64>;
+
+
+#[test]
+fn issue_57_object_remove() {
+	let mut world: ObjectCollisionWorld = CollisionWorld::new(0.1, 0.1, false);
+    let shape = Arc::new(Box::new(Ball::new(1.0)) as Box<ShapeRepr>);
+    world.add(0,
+              Iso2::new(Vec2::new(1.0, 0.0), Vec1::new(0.0)),
+              shape.clone(),
+              CollisionGroups::new(),
+              ());
+   world.add(1,
+              Iso2::new(Vec2::new(1.0, 1.0), Vec1::new(0.0)),
+              shape.clone(),
+              CollisionGroups::new(),
+              ());
+	world.add(2,
+              Iso2::new(Vec2::new(1.0, 2.0), Vec1::new(0.0)),
+              shape.clone(),
+              CollisionGroups::new(),
+              ());
+    world.update();
+    world.remove(0);
+    world.update();
+}

--- a/ncollide_pipeline/tests/collision_world.rs
+++ b/ncollide_pipeline/tests/collision_world.rs
@@ -34,4 +34,5 @@ fn issue_57_object_remove() {
     world.update();
     world.remove(0);
     world.update();
+    world.update();
 }

--- a/ncollide_utils/Cargo.toml
+++ b/ncollide_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ncollide_utils"
-version = "0.2.3"
+version = "0.2.4"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 

--- a/ncollide_utils/data/hash_map.rs
+++ b/ncollide_utils/data/hash_map.rs
@@ -209,13 +209,13 @@ impl<K: PartialEq, V, H: HashFun<K>> HashMap<K, V, H> {
                     return None
                 }
 
-                obji                             = self.next[o as usize];
-                self.next[o as usize]    = self.next[obji as usize];
+                obji = self.next[o as usize];
+                self.next[o as usize] = self.next[obji as usize];
                 self.next[obji as usize] = -1;
             }
             else {
                 obji = o;
-                self.htable[h]       = self.next[o as usize];
+                self.htable[h] = self.next[o as usize];
                 self.next[o as usize] = -1;
             }
 
@@ -239,7 +239,7 @@ impl<K: PartialEq, V, H: HashFun<K>> HashMap<K, V, H> {
                     self.next[no as usize] = obji;
                 }
 
-                self.next[obji as usize]  = self.next[self.num_elem];
+                self.next[obji as usize] = self.next[self.num_elem];
                 self.next[self.num_elem] = -1;
             }
 


### PR DESCRIPTION
Objects removal was not handled properly at several places:
* some collision pairs involving deleted objects were not properly removed by the broad phase.
* the collision world removed the collision objects too soon (before the broad phase had a chance to report the proximity loss event).

The solution here is to defer object removal from the collision world until an update is made.
Therefore, the `.remove(...)` method of `CollisionWorld` was renamed to `.deferred_remove(...)`. A new method `.perform_removals_and_broad_phase()` actually applies the removal but, as a side effect, triggers a broad phase update as well.

This fix also renames all the methods including the word `defered` to `deferred` (with two 'r').

Actually fixes #57.