### PR TITLE
Use u32 instead of usize in index type of Polyline & TriMesh.

### DIFF
--- a/examples/mesh2d.rs
+++ b/examples/mesh2d.rs
@@ -10,7 +10,7 @@ fn main() {
         Pnt2::new(0.0, 1.0),  Pnt2::new(-1.0, -1.0),
         Pnt2::new(0.0, -0.5), Pnt2::new(1.0, -1.0));
 
-    let indices = vec!(Pnt2::new(0usize, 1),
+    let indices = vec!(Pnt2::new(0u32, 1),
                        Pnt2::new(1,  2),
                        Pnt2::new(2,  3),
                        Pnt2::new(3,  1));

--- a/examples/mesh3d.rs
+++ b/examples/mesh3d.rs
@@ -10,7 +10,7 @@ fn main() {
         Pnt3::new(0.0, 1.0, 0.0), Pnt3::new(-1.0, -0.5, 0.0),
         Pnt3::new(0.0, -0.5, -1.0), Pnt3::new(1.0, -0.5, 0.0));
 
-    let indices = vec!(Pnt3::new(0usize, 1, 2),
+    let indices = vec!(Pnt3::new(0u32, 1, 2),
                        Pnt3::new(0,  2, 3),
                        Pnt3::new(0,  3, 1));
 

--- a/ncollide_entities/shape/polyline.rs
+++ b/ncollide_entities/shape/polyline.rs
@@ -10,7 +10,7 @@ use math::{Scalar, Point, Vect};
 
 /// Shape commonly known as a 2d line strip or a 3d segment mesh.
 pub struct Polyline<P: Point> {
-    mesh: BaseMesh<P, Pnt2<usize>, Segment<P>>
+    mesh: BaseMesh<P, Pnt2<u32>, Segment<P>>
 }
 
 impl<P: Point> Clone for Polyline<P> {
@@ -26,7 +26,7 @@ impl<P> Polyline<P>
           P::Vect: Translate<P> {
     /// Builds a new mesh.
     pub fn new(vertices: Arc<Vec<P>>,
-               indices:  Arc<Vec<Pnt2<usize>>>,
+               indices:  Arc<Vec<Pnt2<u32>>>,
                uvs:      Option<Arc<Vec<Pnt2<<P::Vect as Vect>::Scalar>>>>,
                normals:  Option<Arc<Vec<P::Vect>>>) // a loosening margin for the BVT.
                -> Polyline<P> {
@@ -40,7 +40,7 @@ impl<P> Polyline<P>
     where P: Point {
     /// The base representation of this mesh.
     #[inline]
-    pub fn base_mesh(&self) -> &BaseMesh<P, Pnt2<usize>, Segment<P>> {
+    pub fn base_mesh(&self) -> &BaseMesh<P, Pnt2<u32>, Segment<P>> {
         &self.mesh
     }
 
@@ -58,7 +58,7 @@ impl<P> Polyline<P>
 
     /// The indices of this mesh.
     #[inline]
-    pub fn indices(&self) -> &Arc<Vec<Pnt2<usize>>> {
+    pub fn indices(&self) -> &Arc<Vec<Pnt2<u32>>> {
         unsafe { mem::transmute(self.mesh.indices()) }
     }
 

--- a/ncollide_entities/shape/segment.rs
+++ b/ncollide_entities/shape/segment.rs
@@ -39,9 +39,9 @@ impl<P> Segment<P> {
     }
 }
 
-impl<P: Dim + Copy> BaseMeshElement<Pnt2<usize>, P> for Segment<P> {
+impl<P: Dim + Copy> BaseMeshElement<Pnt2<u32>, P> for Segment<P> {
     #[inline]
-    fn new_with_vertices_and_indices(vs: &[P], is: &Pnt2<usize>) -> Segment<P> {
-        Segment::new(vs[is.x], vs[is.y])
+    fn new_with_vertices_and_indices(vs: &[P], is: &Pnt2<u32>) -> Segment<P> {
+        Segment::new(vs[is.x as usize], vs[is.y as usize])
     }
 }

--- a/ncollide_entities/shape/triangle.rs
+++ b/ncollide_entities/shape/triangle.rs
@@ -47,9 +47,9 @@ impl<P> Triangle<P> {
     }
 }
 
-impl<P: Copy + Dim> BaseMeshElement<Pnt3<usize>, P> for Triangle<P> {
+impl<P: Copy + Dim> BaseMeshElement<Pnt3<u32>, P> for Triangle<P> {
     #[inline]
-    fn new_with_vertices_and_indices(vs: &[P], is: &Pnt3<usize>) -> Triangle<P> {
-        Triangle::new(vs[is.x], vs[is.y], vs[is.z])
+    fn new_with_vertices_and_indices(vs: &[P], is: &Pnt3<u32>) -> Triangle<P> {
+        Triangle::new(vs[is.x as usize], vs[is.y as usize], vs[is.z as usize])
     }
 }

--- a/ncollide_entities/shape/trimesh.rs
+++ b/ncollide_entities/shape/trimesh.rs
@@ -9,7 +9,7 @@ use math::{Scalar, Point, Vect};
 
 /// Shape commonly known as a 2d line strip or a 3d triangle mesh.
 pub struct TriMesh<P: Point> {
-    mesh: BaseMesh<P, Pnt3<usize>, Triangle<P>>
+    mesh: BaseMesh<P, Pnt3<u32>, Triangle<P>>
 }
 
 impl<P: Point> Clone for TriMesh<P> {
@@ -25,7 +25,7 @@ impl<P> TriMesh<P>
           P::Vect: Translate<P> {
     /// Builds a new mesh.
     pub fn new(vertices: Arc<Vec<P>>,
-               indices:  Arc<Vec<Pnt3<usize>>>,
+               indices:  Arc<Vec<Pnt3<u32>>>,
                uvs:      Option<Arc<Vec<Pnt2<<P::Vect as Vect>::Scalar>>>>,
                normals:  Option<Arc<Vec<P::Vect>>>) // a loosening margin for the BVT.
                -> TriMesh<P> {
@@ -39,7 +39,7 @@ impl<P> TriMesh<P>
     where P: Point {
     /// The base representation of this mesh.
     #[inline]
-    pub fn base_mesh(&self) -> &BaseMesh<P, Pnt3<usize>, Triangle<P>> {
+    pub fn base_mesh(&self) -> &BaseMesh<P, Pnt3<u32>, Triangle<P>> {
         &self.mesh
     }
 
@@ -57,7 +57,7 @@ impl<P> TriMesh<P>
 
     /// The indices of this mesh.
     #[inline]
-    pub fn indices(&self) -> &Arc<Vec<Pnt3<usize>>> {
+    pub fn indices(&self) -> &Arc<Vec<Pnt3<u32>>> {
         self.mesh.indices()
     }
 


### PR DESCRIPTION
Currently, it's troublesome passing Polyline's & TriMesh's indicies to OpenGL.

The Polyline/TriMesh-types in ncollide_procedual are using Pnt2<u32>/Pnt3<u32>, too.

*edit: Missed to do a proper test on my machine, seeing the travis error right now, fixing that part...