### PR TITLE
Add copy trait for geometry

### DIFF
--- a/ncollide_geometry/shape/ball.rs
+++ b/ncollide_geometry/shape/ball.rs
@@ -9,6 +9,8 @@ pub struct Ball<N> {
     radius: N
 }
 
+impl<N> Copy for Ball<N> where N: Copy {}
+
 impl<N: Scalar> Ball<N> {
     /// Creates a new ball from its radius and center.
     #[inline]

--- a/ncollide_geometry/shape/capsule.rs
+++ b/ncollide_geometry/shape/capsule.rs
@@ -13,6 +13,8 @@ pub struct Capsule<N> {
     radius:      N,
 }
 
+impl<N> Copy for Capsule<N> where N: Copy {}
+
 impl<N> Capsule<N>
     where N: Scalar {
     /// Creates a new capsule.

--- a/ncollide_geometry/shape/cone.rs
+++ b/ncollide_geometry/shape/cone.rs
@@ -13,6 +13,8 @@ pub struct Cone<N> {
     radius:      N,
 }
 
+impl<N> Copy for Cone<N> where N: Copy {}
+
 impl<N> Cone<N>
     where N: Scalar {
     /// Creates a new cone.

--- a/ncollide_geometry/shape/cuboid.rs
+++ b/ncollide_geometry/shape/cuboid.rs
@@ -10,6 +10,8 @@ pub struct Cuboid<V> {
     half_extents: V,
 }
 
+impl<V> Copy for Cuboid<V> where V: Copy {}
+
 impl<V: Vector> Cuboid<V> {
     /// Creates a new box from its half-extents. Half-extents are the box half-width along each
     /// axis. Each half-extent must be greater than 0.04.

--- a/ncollide_geometry/shape/cylinder.rs
+++ b/ncollide_geometry/shape/cylinder.rs
@@ -15,6 +15,8 @@ pub struct Cylinder<N> {
     radius:      N,
 }
 
+impl<N> Copy for Cylinder<N> where N: Copy {}
+
 impl<N> Cylinder<N>
     where N: Scalar {
     /// Creates a new cylinder.

--- a/ncollide_geometry/shape/plane.rs
+++ b/ncollide_geometry/shape/plane.rs
@@ -9,6 +9,8 @@ pub struct Plane<V> {
     normal: V
 }
 
+impl<N> Copy for Plane<N> where N: Copy {}
+
 impl<V: Vector> Plane<V> {
     /// Builds a new plane from its center and its normal.
     #[inline]

--- a/ncollide_geometry/shape/segment.rs
+++ b/ncollide_geometry/shape/segment.rs
@@ -12,6 +12,8 @@ pub struct Segment<P> {
     b: P
 }
 
+impl<P> Copy for Segment<P> where P: Copy {}
+
 impl<P: Dimension> Segment<P> {
     /// Creates a new segment from two points.
     #[inline]

--- a/ncollide_geometry/shape/torus.rs
+++ b/ncollide_geometry/shape/torus.rs
@@ -6,6 +6,8 @@ pub struct Torus<N> {
     minor_radius: N
 }
 
+impl<N> Copy for Torus<N> where N: Copy {}
+
 impl<N> Torus<N> {
     /// Creates a new torus with the given radiuses.
     #[inline]

--- a/ncollide_geometry/shape/triangle.rs
+++ b/ncollide_geometry/shape/triangle.rs
@@ -13,6 +13,8 @@ pub struct Triangle<P> {
     c: P
 }
 
+impl<P> Copy for Triangle<P> where P: Copy {}
+
 impl<P: Dimension> Triangle<P> {
     /// Creates a triangle from three points.
     #[inline]


### PR DESCRIPTION
I've had to recently make a struct that contained a Cuboid to be `Copy`, but I couldn't since it doesn't implement it.

Is this something that would be accepted?
