### PR TITLE
Return additional information from a point projection

### DIFF
--- a/ncollide_geometry/query/mod.rs
+++ b/ncollide_geometry/query/mod.rs
@@ -18,7 +18,7 @@ pub use self::ray_internal::{Ray, Ray2, Ray3,
                              RayCast, RayInterferencesCollector,
                              RayIntersectionCostFn};
 #[doc(inline)]
-pub use self::point_internal::{PointProjection, PointQuery, PointInterferencesCollector};
+pub use self::point_internal::{AdvancedPointQuery, PointProjection, PointQuery, PointInterferencesCollector};
 
 pub mod algorithms;
 pub mod contacts_internal;

--- a/ncollide_geometry/query/point_internal/mod.rs
+++ b/ncollide_geometry/query/point_internal/mod.rs
@@ -1,7 +1,7 @@
 //! Point inclusion and projection.
 
 #[doc(inline)]
-pub use self::point_query::{PointQuery, PointProjection};
+pub use self::point_query::{AdvancedPointQuery, PointQuery, PointProjection};
 pub use self::point_bvt::PointInterferencesCollector;
 
 #[doc(hidden)]

--- a/ncollide_geometry/query/point_internal/point_aabb.rs
+++ b/ncollide_geometry/query/point_internal/point_aabb.rs
@@ -15,7 +15,7 @@ impl<P: Point, M: Isometry<P>> PointQuery<P, M> for AABB<P> {
         let inside = shift == na::zero();
 
         if !inside || solid {
-            PointProjection::new(inside, *pt + m.rotate_vector(&shift))
+            PointProjection::new(inside, *pt + m.rotate_vector(&shift), ())
         }
         else {
             let _max: P::Real = Bounded::max_value();
@@ -47,7 +47,7 @@ impl<P: Point, M: Isometry<P>> PointQuery<P, M> for AABB<P> {
                 shift[best_id as usize] = -best;
             }
 
-            PointProjection::new(inside, *pt + m.rotate_vector(&shift))
+            PointProjection::new(inside, *pt + m.rotate_vector(&shift), ())
         }
     }
 

--- a/ncollide_geometry/query/point_internal/point_ball.rs
+++ b/ncollide_geometry/query/point_internal/point_ball.rs
@@ -14,12 +14,12 @@ impl<P: Point, M: Isometry<P>> PointQuery<P, M> for Ball<P::Real> {
         let inside = distance_squared <= self.radius() * self.radius();
 
         if inside && solid {
-            PointProjection::new(true, *pt)
+            PointProjection::new(true, *pt, ())
         }
         else {
             let ls_proj = P::origin() + ls_pt.coordinates() / distance_squared.sqrt();
 
-            PointProjection::new(inside, m.translate_point(&ls_proj))
+            PointProjection::new(inside, m.translate_point(&ls_proj), ())
         }
     }
 

--- a/ncollide_geometry/query/point_internal/point_mesh.rs
+++ b/ncollide_geometry/query/point_internal/point_mesh.rs
@@ -53,7 +53,7 @@ impl<'a, P, I, E> BVTCostFn<P::Real, usize, AABB<P>> for BaseMeshPointProjCostFn
     }
 
     #[inline]
-    fn compute_b_cost(&mut self, b: &usize) -> Option<(P::Real, PointProjection<P>)> {
+    fn compute_b_cost(&mut self, b: &usize) -> Option<(P::Real, Self::UserData)> {
         let proj = self.mesh.element_at(*b).project_point(&Id::new(), self.point, true);
 
         Some((na::distance(self.point, &proj.point), proj))

--- a/ncollide_geometry/query/point_internal/point_mesh.rs
+++ b/ncollide_geometry/query/point_internal/point_mesh.rs
@@ -1,6 +1,6 @@
 use alga::general::Id;
 use na;
-use query::{PointQuery, PointProjection};
+use query::{AdvancedPointQuery, PointQuery, PointProjection};
 use shape::{BaseMesh, BaseMeshElement, TriMesh, Polyline};
 use bounding_volume::AABB;
 use partitioning::{BVTCostFn, BVTVisitor};
@@ -10,16 +10,10 @@ use math::{Point, Isometry};
 impl<P, M, I, E> PointQuery<P, M> for BaseMesh<P, I, E>
     where P: Point,
           M: Isometry<P>,
-          E: BaseMeshElement<I, P> + PointQuery<P, Id> {
+          E: BaseMeshElement<I, P> + PointQuery<P, Id> + AdvancedPointQuery<P, Id> {
     #[inline]
-    fn project_point(&self, m: &M, point: &P, _: bool) -> PointProjection<P> {
-        let ls_pt = m.inverse_transform_point(point);
-        let mut cost_fn = BaseMeshPointProjCostFn { mesh: self, point: &ls_pt };
-
-        let mut proj = self.bvt().best_first_search(&mut cost_fn).unwrap().1;
-        proj.point = m.transform_point(&proj.point);
-
-        proj
+    fn project_point(&self, m: &M, point: &P, solid: bool) -> PointProjection<P> {
+        self.project_point_with_info(m, point, solid).without_info()
     }
 
     #[inline]
@@ -30,6 +24,27 @@ impl<P, M, I, E> PointQuery<P, M> for BaseMesh<P, I, E>
         self.bvt().visit(&mut test);
 
         test.found
+    }
+}
+
+impl<P, M, I, E> AdvancedPointQuery<P, M> for BaseMesh<P, I, E>
+    where P: Point,
+          M: Isometry<P>,
+          E: BaseMeshElement<I, P> + AdvancedPointQuery<P, Id>
+{
+    type ProjectionInfo = PointProjectionInfo<E::ProjectionInfo>;
+
+    #[inline]
+    fn project_point_with_info(&self, m: &M, point: &P, _: bool)
+        -> PointProjection<P, Self::ProjectionInfo>
+    {
+        let ls_pt = m.inverse_transform_point(point);
+        let mut cost_fn = BaseMeshPointProjCostFn { mesh: self, point: &ls_pt };
+
+        let mut proj = self.bvt().best_first_search(&mut cost_fn).unwrap().1;
+        proj.point = m.transform_point(&proj.point);
+
+        proj
     }
 }
 
@@ -44,8 +59,8 @@ struct BaseMeshPointProjCostFn<'a, P: 'a + Point, I: 'a, E: 'a> {
 
 impl<'a, P, I, E> BVTCostFn<P::Real, usize, AABB<P>> for BaseMeshPointProjCostFn<'a, P, I, E>
     where P: Point,
-          E: BaseMeshElement<I, P> + PointQuery<P, Id> {
-    type UserData = PointProjection<P>;
+          E: BaseMeshElement<I, P> + AdvancedPointQuery<P, Id> {
+    type UserData = PointProjection<P, PointProjectionInfo<E::ProjectionInfo>>;
 
     #[inline]
     fn compute_bv_cost(&mut self, aabb: &AABB<P>) -> Option<P::Real> {
@@ -54,7 +69,19 @@ impl<'a, P, I, E> BVTCostFn<P::Real, usize, AABB<P>> for BaseMeshPointProjCostFn
 
     #[inline]
     fn compute_b_cost(&mut self, b: &usize) -> Option<(P::Real, Self::UserData)> {
-        let proj = self.mesh.element_at(*b).project_point(&Id::new(), self.point, true);
+        let proj = self.mesh
+            .element_at(*b)
+            .project_point_with_info(&Id::new(), self.point, true);
+
+        let proj = PointProjection {
+            is_inside: proj.is_inside,
+            point    : proj.point,
+
+            info: PointProjectionInfo {
+                element_index      : *b,
+                position_on_element: proj.info,
+            },
+        };
 
         Some((na::distance(self.point, &proj.point), proj))
     }
@@ -87,6 +114,23 @@ impl<'a, P, I, E> BVTVisitor<usize, AABB<P>> for PointContainementTest<'a, P, I,
         }
     }
 }
+
+
+/// Additional point pojection info for base meshes
+pub struct PointProjectionInfo<P> {
+    /// The index of the base mesh element the point was projected on
+    ///
+    /// The terminology is a bit confusing here, as this is not the index of a
+    /// base mesh vertex, but rather of a base mesh element. Meaning, it is
+    /// intended to be passed to `BaseMesh::element_at`.
+    pub element_index: usize,
+
+    /// Describes where on the base mesh element the point was projected
+    ///
+    /// The type of this field depends on the type of the base mesh element.
+    pub position_on_element: P,
+}
+
 
 /*
  * fwd impls to exact meshes.

--- a/ncollide_geometry/query/point_internal/point_mesh.rs
+++ b/ncollide_geometry/query/point_internal/point_mesh.rs
@@ -1,7 +1,7 @@
 use alga::general::Id;
 use na;
 use query::{AdvancedPointQuery, PointQuery, PointProjection};
-use shape::{BaseMesh, BaseMeshElement, TriMesh, Polyline};
+use shape::{BaseMesh, BaseMeshElement, Segment, TriMesh, Polyline};
 use bounding_volume::AABB;
 use partitioning::{BVTCostFn, BVTVisitor};
 use math::{Point, Isometry};
@@ -152,10 +152,11 @@ impl<P: Point, M: Isometry<P>> PointQuery<P, M> for TriMesh<P> {
     }
 }
 
+
 impl<P: Point, M: Isometry<P>> PointQuery<P, M> for Polyline<P> {
     #[inline]
     fn project_point(&self, m: &M, point: &P, solid: bool) -> PointProjection<P> {
-        self.base_mesh().project_point(m, point, solid)
+        self.project_point_with_info(m, point, solid).without_info()
     }
 
     #[inline]
@@ -166,5 +167,16 @@ impl<P: Point, M: Isometry<P>> PointQuery<P, M> for Polyline<P> {
     #[inline]
     fn contains_point(&self, m: &M, point: &P) -> bool {
         self.base_mesh().contains_point(m, point)
+    }
+}
+
+impl<P: Point, M: Isometry<P>> AdvancedPointQuery<P, M> for Polyline<P> {
+    type ProjectionInfo = PointProjectionInfo<<Segment<P> as AdvancedPointQuery<P, M>>::ProjectionInfo>;
+
+    #[inline]
+    fn project_point_with_info(&self, m: &M, point: &P, solid: bool)
+        -> PointProjection<P, Self::ProjectionInfo>
+    {
+        self.base_mesh().project_point_with_info(m, point, solid)
     }
 }

--- a/ncollide_geometry/query/point_internal/point_plane.rs
+++ b/ncollide_geometry/query/point_internal/point_plane.rs
@@ -12,10 +12,10 @@ impl<P: Point, M: Isometry<P>> PointQuery<P, M> for Plane<P::Vector> {
         let inside = d <= na::zero();
 
         if inside && solid {
-            PointProjection::new(true, *pt)
+            PointProjection::new(true, *pt, ())
         }
         else {
-            PointProjection::new(inside, *pt + (-*self.normal() * d))
+            PointProjection::new(inside, *pt + (-*self.normal() * d), ())
         }
     }
 

--- a/ncollide_geometry/query/point_internal/point_query.rs
+++ b/ncollide_geometry/query/point_internal/point_query.rs
@@ -57,3 +57,32 @@ pub trait PointQuery<P: Point, M> {
         self.project_point(m, pt, false).is_inside
     }
 }
+
+/// Returns shape-specific info in addition to generic projection information
+///
+/// One requirement for the `PointQuery` trait is to be usable as a trait
+/// object. Unfortunately this precludes us from adding an associated type to it
+/// that might allow us to return shape-specific information in addition to the
+/// general information provided in `PointProjection`. This is where
+/// `AdvancedPointQuery` comes in. It forgos the ability to be used as a trait
+/// object in exchange for being able to provide shape-specific projection
+/// information.
+///
+/// Any types that implement `PointQuery` but are able to provide additional
+/// information, can implement `AdvancedPointQuery` in addition and have their
+/// `PointQuery::project_point` implementation just call out to
+/// `AdvancedPointQuery::project_point_with_info`.
+pub trait AdvancedPointQuery<P: Point, M> {
+    /// Additional shape-specific projection information
+    ///
+    /// In addition to the generic projection information returned in
+    /// `PointProjection`, implementations might provide shape-specific
+    /// projection info. The type of this shape-specific information is defined
+    /// by this associated type.
+    type ProjectionInfo;
+
+    /// Projects a point on `self` transformed by `m`.
+    #[inline]
+    fn project_point_with_info(&self, m: &M, pt: &P, solid: bool)
+        -> PointProjection<P, Self::ProjectionInfo>;
+}

--- a/ncollide_geometry/query/point_internal/point_query.rs
+++ b/ncollide_geometry/query/point_internal/point_query.rs
@@ -20,6 +20,15 @@ impl<P: Point, I> PointProjection<P, I> {
             info:      info,
         }
     }
+
+    /// Strips the additional, query-specific information
+    pub fn without_info(self) -> PointProjection<P> {
+        PointProjection {
+            is_inside: self.is_inside,
+            point:     self.point,
+            info:      (),
+        }
+    }
 }
 
 /// Trait of objects that can be tested for point inclusion and projection.

--- a/ncollide_geometry/query/point_internal/point_query.rs
+++ b/ncollide_geometry/query/point_internal/point_query.rs
@@ -2,19 +2,22 @@ use na;
 use math::Point;
 
 /// Description of the projection of a point on a shape.
-pub struct PointProjection<P: Point> {
+pub struct PointProjection<P: Point, I = ()> {
     /// Whether or not the point to project was inside of the shape.
     pub is_inside: bool,
     /// The projection result.
     pub point: P,
+    /// Additional projection results whose type is dependent on the shape type.
+    pub info: I,
 }
 
-impl<P: Point> PointProjection<P> {
+impl<P: Point, I> PointProjection<P, I> {
     /// Initializes a new `PointProjection`.
-    pub fn new(is_inside: bool, point: P) -> PointProjection<P> {
+    pub fn new(is_inside: bool, point: P, info: I) -> PointProjection<P, I> {
         PointProjection {
             is_inside: is_inside,
-            point:     point
+            point:     point,
+            info:      info,
         }
     }
 }

--- a/ncollide_geometry/query/point_internal/point_segment.rs
+++ b/ncollide_geometry/query/point_internal/point_segment.rs
@@ -15,10 +15,7 @@ impl<P: Point, M: Isometry<P>> PointQuery<P, M> for Segment<P> {
 }
 
 impl<P: Point, M: Isometry<P>> AdvancedPointQuery<P, M> for Segment<P> {
-    // Implementing this trait while providing no projection info might seem
-    // nonsensical, but it actually makes it possible to complete the
-    // `AdvancedPointQuery` implementation for `BaseMesh`.
-    type ProjectionInfo = ();
+    type ProjectionInfo = P::Real;
 
     #[inline]
     fn project_point_with_info(&self, m: &M, pt: &P, _: bool)
@@ -31,25 +28,29 @@ impl<P: Point, M: Isometry<P>> AdvancedPointQuery<P, M> for Segment<P> {
         let sqnab = na::norm_squared(&ab);
 
         let proj;
+        let position_on_segment;
 
         if ab_ap <= na::zero() {
             // Voronoï region of vertex 'a'.
+            position_on_segment = na::zero();
             proj = m.transform_point(self.a());
         }
         else if ab_ap >= sqnab {
             // Voronoï region of vertex 'b'.
+            position_on_segment = na::one();
             proj = m.transform_point(self.b());
         }
         else {
             assert!(sqnab != na::zero());
 
             // Voronoï region of the segment interior.
-            proj = m.transform_point(&(*self.a() + ab * (ab_ap / sqnab)));
+            position_on_segment = ab_ap / sqnab;
+            proj = m.transform_point(&(*self.a() + ab * position_on_segment));
         }
 
         // FIXME: is this acceptable?
         let inside = relative_eq!(proj, *pt);
 
-        PointProjection::new(inside, proj, ())
+        PointProjection::new(inside, proj, position_on_segment)
     }
 }

--- a/ncollide_geometry/query/point_internal/point_segment.rs
+++ b/ncollide_geometry/query/point_internal/point_segment.rs
@@ -1,12 +1,29 @@
 use na;
 use shape::Segment;
-use query::{PointQuery, PointProjection};
+use query::{AdvancedPointQuery, PointQuery, PointProjection};
 use math::{Point, Isometry};
 
 
 impl<P: Point, M: Isometry<P>> PointQuery<P, M> for Segment<P> {
     #[inline]
-    fn project_point(&self, m: &M, pt: &P, _: bool) -> PointProjection<P> {
+    fn project_point(&self, m: &M, pt: &P, solid: bool) -> PointProjection<P> {
+        self.project_point_with_info(m, pt, solid).without_info()
+    }
+
+    // NOTE: the default implementation of `.distance_to_point(...)` will return the error that was
+    // eaten by the `::approx_eq(...)` on `project_point(...)`.
+}
+
+impl<P: Point, M: Isometry<P>> AdvancedPointQuery<P, M> for Segment<P> {
+    // Implementing this trait while providing no projection info might seem
+    // nonsensical, but it actually makes it possible to complete the
+    // `AdvancedPointQuery` implementation for `BaseMesh`.
+    type ProjectionInfo = ();
+
+    #[inline]
+    fn project_point_with_info(&self, m: &M, pt: &P, _: bool)
+        -> PointProjection<P, Self::ProjectionInfo>
+    {
         let ls_pt = m.inverse_transform_point(pt);
         let ab    = *self.b() - *self.a();
         let ap    = ls_pt - *self.a();
@@ -35,7 +52,4 @@ impl<P: Point, M: Isometry<P>> PointQuery<P, M> for Segment<P> {
 
         PointProjection::new(inside, proj, ())
     }
-
-    // NOTE: the default implementation of `.distance_to_point(...)` will return the error that was
-    // eaten by the `::approx_eq(...)` on `project_point(...)`.
 }

--- a/ncollide_geometry/query/point_internal/point_segment.rs
+++ b/ncollide_geometry/query/point_internal/point_segment.rs
@@ -33,7 +33,7 @@ impl<P: Point, M: Isometry<P>> PointQuery<P, M> for Segment<P> {
         // FIXME: is this acceptable?
         let inside = relative_eq!(proj, *pt);
 
-        PointProjection::new(inside, proj)
+        PointProjection::new(inside, proj, ())
     }
 
     // NOTE: the default implementation of `.distance_to_point(...)` will return the error that was

--- a/ncollide_geometry/query/point_internal/point_support_map.rs
+++ b/ncollide_geometry/query/point_internal/point_support_map.rs
@@ -27,7 +27,7 @@ pub fn support_map_point_projection<P, M, S, G>(m:       &M,
 
     match gjk::project_origin(&m, shape, simplex) {
         Some(p) => {
-            PointProjection::new(false, p + point.coordinates())
+            PointProjection::new(false, p + point.coordinates(), ())
         },
         None => {
             let proj;
@@ -45,7 +45,7 @@ pub fn support_map_point_projection<P, M, S, G>(m:       &M,
                 proj = *point
             }
 
-            PointProjection::new(true, proj)
+            PointProjection::new(true, proj, ())
         }
     }
 }

--- a/ncollide_geometry/query/point_internal/point_triangle.rs
+++ b/ncollide_geometry/query/point_internal/point_triangle.rs
@@ -6,12 +6,12 @@ use math::{Point, Isometry};
 #[inline]
 fn compute_result<P: Point>(pt: &P, proj: P) -> PointProjection<P> {
    if na::dimension::<P::Vector>() == 2 {
-       PointProjection::new(*pt == proj, proj)
+       PointProjection::new(*pt == proj, proj, ())
    }
    else {
        // FIXME: is this acceptable to assume the point is inside of the triangle if it is close
        // enough?
-       PointProjection::new(relative_eq!(proj, *pt), proj)
+       PointProjection::new(relative_eq!(proj, *pt), proj, ())
    }
 }
 
@@ -94,7 +94,7 @@ impl<P: Point, M: Isometry<P>> PointQuery<P, M> for Triangle<P> {
             // Special treatement if we work in 2d because in this case we really are inside of the
             // object.
             if solid {
-                PointProjection::new(true, *pt)
+                PointProjection::new(true, *pt, ())
             }
             else {
                 // We have to project on the closest edge.
@@ -132,7 +132,7 @@ impl<P: Point, M: Isometry<P>> PointQuery<P, M> for Triangle<P> {
                     }
                 }
 
-                PointProjection::new(true, proj)
+                PointProjection::new(true, proj, ())
             }
         }
     }


### PR DESCRIPTION
This pull request adds infrastructure to return additional information for a point projection. It also uses this infrastructure to return more information for point projections onto a `Polyline`, namely the index of the segment that was projected on, and the position of the projected point on that segment.

I've tested this in my project and, as far as I can tell, it works like a charm :-)

Closes #147 