### PR TITLE
Return additional information from a point projection

### DIFF
--- a/ncollide_geometry/query/mod.rs
+++ b/ncollide_geometry/query/mod.rs
@@ -18,7 +18,7 @@ pub use self::ray_internal::{Ray, Ray2, Ray3,
                              RayCast, RayInterferencesCollector,
                              RayIntersectionCostFn};
 #[doc(inline)]
-pub use self::point_internal::{PointProjection, PointQuery, PointInterferencesCollector};
+pub use self::point_internal::{PointProjection, PointQuery, PointInterferencesCollector, RichPointQuery};
 
 pub mod algorithms;
 pub mod contacts_internal;

--- a/ncollide_geometry/query/point_internal/mod.rs
+++ b/ncollide_geometry/query/point_internal/mod.rs
@@ -1,7 +1,7 @@
 //! Point inclusion and projection.
 
 #[doc(inline)]
-pub use self::point_query::{PointQuery, PointProjection};
+pub use self::point_query::{PointQuery, PointProjection, RichPointQuery};
 pub use self::point_bvt::PointInterferencesCollector;
 
 #[doc(hidden)]

--- a/ncollide_geometry/query/point_internal/point_mesh.rs
+++ b/ncollide_geometry/query/point_internal/point_mesh.rs
@@ -53,7 +53,7 @@ impl<'a, P, I, E> BVTCostFn<P::Real, usize, AABB<P>> for BaseMeshPointProjCostFn
     }
 
     #[inline]
-    fn compute_b_cost(&mut self, b: &usize) -> Option<(P::Real, PointProjection<P>)> {
+    fn compute_b_cost(&mut self, b: &usize) -> Option<(P::Real, Self::UserData)> {
         let proj = self.mesh.element_at(*b).project_point(&Id::new(), self.point, true);
 
         Some((na::distance(self.point, &proj.point), proj))

--- a/ncollide_geometry/query/point_internal/point_mesh.rs
+++ b/ncollide_geometry/query/point_internal/point_mesh.rs
@@ -1,7 +1,7 @@
 use alga::general::Id;
 use na;
 use query::{PointQuery, PointProjection, RichPointQuery};
-use shape::{BaseMesh, BaseMeshElement, TriMesh, Polyline};
+use shape::{BaseMesh, BaseMeshElement, Segment, TriMesh, Polyline};
 use bounding_volume::AABB;
 use partitioning::{BVTCostFn, BVTVisitor};
 use math::{Point, Isometry};
@@ -148,10 +148,12 @@ impl<P: Point, M: Isometry<P>> PointQuery<P, M> for TriMesh<P> {
     }
 }
 
+
 impl<P: Point, M: Isometry<P>> PointQuery<P, M> for Polyline<P> {
     #[inline]
     fn project_point(&self, m: &M, point: &P, solid: bool) -> PointProjection<P> {
-        self.base_mesh().project_point(m, point, solid)
+        let (projection, _) = self.project_point_with_extra_info(m, point, solid);
+        projection
     }
 
     #[inline]
@@ -162,5 +164,16 @@ impl<P: Point, M: Isometry<P>> PointQuery<P, M> for Polyline<P> {
     #[inline]
     fn contains_point(&self, m: &M, point: &P) -> bool {
         self.base_mesh().contains_point(m, point)
+    }
+}
+
+impl<P: Point, M: Isometry<P>> RichPointQuery<P, M> for Polyline<P> {
+    type ExtraInfo = PointProjectionInfo<<Segment<P> as RichPointQuery<P, M>>::ExtraInfo>;
+
+    #[inline]
+    fn project_point_with_extra_info(&self, m: &M, point: &P, solid: bool)
+        -> (PointProjection<P>, Self::ExtraInfo)
+    {
+        self.base_mesh().project_point_with_extra_info(m, point, solid)
     }
 }

--- a/ncollide_geometry/query/point_internal/point_query.rs
+++ b/ncollide_geometry/query/point_internal/point_query.rs
@@ -45,3 +45,32 @@ pub trait PointQuery<P: Point, M> {
         self.project_point(m, pt, false).is_inside
     }
 }
+
+/// Returns shape-specific info in addition to generic projection information
+///
+/// One requirement for the `PointQuery` trait is to be usable as a trait
+/// object. Unfortunately this precludes us from adding an associated type to it
+/// that might allow us to return shape-specific information in addition to the
+/// general information provided in `PointProjection`. This is where
+/// `RichPointQuery` comes in. It forgoes the ability to be used as a trait
+/// object in exchange for being able to provide shape-specific projection
+/// information.
+///
+/// Any shapes that implement `PointQuery` but are able to provide extra
+/// information, can implement `RichPointQuery` in addition and have their
+/// `PointQuery::project_point` implementation just call out to
+/// `RichPointQuery::project_point_with_extra_info`.
+pub trait RichPointQuery<P: Point, M> {
+    /// Additional shape-specific projection information
+    ///
+    /// In addition to the generic projection information returned in
+    /// `PointProjection`, implementations might provide shape-specific
+    /// projection info. The type of this shape-specific information is defined
+    /// by this associated type.
+    type ExtraInfo;
+
+    /// Projects a point on `self` transformed by `m`.
+    #[inline]
+    fn project_point_with_extra_info(&self, m: &M, pt: &P, solid: bool)
+        -> (PointProjection<P>, Self::ExtraInfo);
+}


### PR DESCRIPTION
This is a continuation of #148, which I closed accidentally.

@sebcrozet, I incorporated the changed you requested. I also played around with the names a bit, and am much happier about them now.

The only name I don't particularly like is `project_point_with_extra_info`, as it's a bit long. I can't think of anything better though. `project_point_with_info` was just plain wrong (The regular `project_point` also returns "info"). `project_point` would be perfect, of course, but would introduce ambiguity and require ugly syntax at call sites.

Closes #147.