### PR TITLE
make collision world impl Sync Send

### DIFF
--- a/ncollide_pipeline/broad_phase/broad_phase.rs
+++ b/ncollide_pipeline/broad_phase/broad_phase.rs
@@ -2,7 +2,7 @@ use geometry::query::Ray;
 use math::Point;
 
 /// Trait all broad phase must implement.
-pub trait BroadPhase<P: Point, BV, T> {
+pub trait BroadPhase<P: Point, BV, T> : Send + Sync {
     /// Tells the broad phase to add an element during the next update.
     fn deferred_add(&mut self, uid: usize, bv: BV, data: T);
 

--- a/ncollide_pipeline/broad_phase/broad_phase_pair_filter.rs
+++ b/ncollide_pipeline/broad_phase/broad_phase_pair_filter.rs
@@ -2,7 +2,7 @@ use world::CollisionObject;
 use math::Point;
 
 /// A signal handler for contact detection.
-pub trait BroadPhasePairFilter<P: Point, M, T> {
+pub trait BroadPhasePairFilter<P: Point, M, T> : Sync + Send {
     /// Activate an action for when two objects start or stop to be close to each other.
     fn is_pair_valid(&self, b1: &CollisionObject<P, M, T>, b2: &CollisionObject<P, M, T>) -> bool;
 }

--- a/ncollide_pipeline/broad_phase/brute_force_broad_phase.rs
+++ b/ncollide_pipeline/broad_phase/brute_force_broad_phase.rs
@@ -29,7 +29,7 @@ impl<N, BV, T> BruteForceBroadPhase<N, BV, T> {
     }
 }
 
-impl<P: Point, BV, T> BroadPhase<P, BV, T> for BruteForceBroadPhase<P::Real, BV, T> where
+impl<P: Point, BV: Sync + Send, T: Sync + Send> BroadPhase<P, BV, T> for BruteForceBroadPhase<P::Real, BV, T> where
     BV: 'static + BoundingVolume<P> +
         RayCast<P, Id> + PointQuery<P, Id> + Clone {
     fn deferred_add(&mut self, uid: usize, bv: BV, data: T) {

--- a/ncollide_pipeline/broad_phase/dbvt_broad_phase.rs
+++ b/ncollide_pipeline/broad_phase/dbvt_broad_phase.rs
@@ -113,7 +113,7 @@ impl<P, BV, T> BroadPhase<P, BV, T> for DBVTBroadPhase<P, BV, T>
             let mut leaf = DBVTLeaf::new(lbv.clone(), FastKey::new_invalid());
             let proxy = DBVTBroadPhaseProxy {
                 data:   data,
-                leaf:   leaf.clone(),
+                leaf:   leaf.clone(vec!(&mut self.tree, &mut self.stree)),
                 active: DEACTIVATION_THRESHOLD
             };
 
@@ -193,7 +193,8 @@ impl<P, BV, T> BroadPhase<P, BV, T> for DBVTBroadPhase<P, BV, T>
             }
 
             self.collector.clear();
-            self.tree.insert(proxy1.leaf.clone());
+            let proxy1_leaf_clone = proxy1.leaf.clone(vec!(&mut self.tree, &mut self.stree));
+            self.tree.insert(proxy1_leaf_clone);
         }
 
         /*
@@ -271,7 +272,8 @@ impl<P, BV, T> BroadPhase<P, BV, T> for DBVTBroadPhase<P, BV, T>
             if proxy.active == 1 {
                 proxy.active = 0;
                 self.tree.remove(&mut proxy.leaf);
-                self.stree.insert(proxy.leaf.clone());
+                let proxy_leaf_clone = proxy.leaf.clone(vec!(&mut self.tree, &mut self.stree));
+                self.stree.insert(proxy_leaf_clone);
             }
             else if proxy.active > 1 {
                 proxy.active = proxy.active - 1;
@@ -306,7 +308,8 @@ impl<P, BV, T> BroadPhase<P, BV, T> for DBVTBroadPhase<P, BV, T>
                 else if proxy.active != DEACTIVATION_THRESHOLD { // If == the object might already be on the update list.
                     if proxy.active == 0 {
                         self.stree.remove(&mut proxy.leaf);
-                        self.tree.insert(proxy.leaf.clone());
+                        let proxy_leaf_clone = proxy.leaf.clone(vec!(&mut self.tree, &mut self.stree));
+                        self.tree.insert(proxy_leaf_clone);
                     }
 
                     proxy.active = DEACTIVATION_THRESHOLD - 1;

--- a/ncollide_pipeline/narrow_phase/contact_generator/contact_generator.rs
+++ b/ncollide_pipeline/narrow_phase/contact_generator/contact_generator.rs
@@ -3,7 +3,7 @@ use geometry::query::Contact;
 use math::Point;
 
 /// Trait implemented algorithms that compute contact points, normals and penetration depths.
-pub trait ContactGenerator<P: Point, M> {
+pub trait ContactGenerator<P: Point, M> : Sync + Send {
     /// Runs the collision detection on two objects. It is assumed that the same
     /// collision detector (the same structure) is always used with the same
     /// pair of object.
@@ -25,7 +25,7 @@ pub trait ContactGenerator<P: Point, M> {
 
 pub type ContactAlgorithm<P, M> = Box<ContactGenerator<P, M> + 'static>;
 
-pub trait ContactDispatcher<P, M> {
+pub trait ContactDispatcher<P, M> : Sync + Send {
     /// Allocate a collision algorithm corresponding to the given pair of shapes.
     fn get_contact_algorithm(&self, a: &Shape<P, M>, b: &Shape<P, M>) -> Option<ContactAlgorithm<P, M>>;
 }

--- a/ncollide_pipeline/narrow_phase/contact_generator/support_map_support_map_contact_generator.rs
+++ b/ncollide_pipeline/narrow_phase/contact_generator/support_map_support_map_contact_generator.rs
@@ -35,7 +35,7 @@ impl<P, M, S> SupportMapSupportMapContactGenerator<P, M, S>
     }
 }
 
-impl<P, M, S> ContactGenerator<P, M> for SupportMapSupportMapContactGenerator<P, M, S>
+impl<P, M, S: Sync + Send> ContactGenerator<P, M> for SupportMapSupportMapContactGenerator<P, M, S>
     where P: Point,
           M: Isometry<P>,
           S: Simplex<AnnotatedPoint<P>> {

--- a/ncollide_pipeline/narrow_phase/contact_signal.rs
+++ b/ncollide_pipeline/narrow_phase/contact_signal.rs
@@ -3,7 +3,7 @@ use narrow_phase::ContactAlgorithm;
 use math::Point;
 
 /// A signal handler for contact detection.
-pub trait ContactHandler<P: Point, M, T> {
+pub trait ContactHandler<P: Point, M, T> : Sync + Send {
     /// Activate an action for when two objects start being in contact.
     fn handle_contact_started(&mut self,
                               co1:      &CollisionObject<P, M, T>,

--- a/ncollide_pipeline/narrow_phase/narrow_phase.rs
+++ b/ncollide_pipeline/narrow_phase/narrow_phase.rs
@@ -12,7 +12,7 @@ use math::Point;
 ///
 /// The narrow phase manager is responsible for creating, updating and generating contact pairs
 /// between objects identified by the broad phase.
-pub trait NarrowPhase<P: Point, M, T> {
+pub trait NarrowPhase<P: Point, M, T> : Sync + Send {
     /// Updates this narrow phase.
     fn update(&mut self,
               objects:          &UidRemap<CollisionObject<P, M, T>>,

--- a/ncollide_pipeline/narrow_phase/proximity_detector/proximity_detector.rs
+++ b/ncollide_pipeline/narrow_phase/proximity_detector/proximity_detector.rs
@@ -3,7 +3,7 @@ use geometry::shape::Shape;
 use math::Point;
 
 /// Trait implemented by algorithms that determine if two objects are in close proximity.
-pub trait ProximityDetector<P: Point, M> {
+pub trait ProximityDetector<P: Point, M> : Sync + Send {
     /// Runs the proximity detection on two objects. It is assumed that the same proximity detector
     /// (the same structure) is always used with the same pair of object.
     fn update(&mut self,
@@ -21,7 +21,7 @@ pub trait ProximityDetector<P: Point, M> {
 
 pub type ProximityAlgorithm<P, M> = Box<ProximityDetector<P, M> + 'static>;
 
-pub trait ProximityDispatcher<P: Point, M> {
+pub trait ProximityDispatcher<P: Point, M> : Sync + Send {
     /// Allocate a collision algorithm corresponding to the given pair of shapes.
     fn get_proximity_algorithm(&self, a: &Shape<P, M>, b: &Shape<P, M>) -> Option<ProximityAlgorithm<P, M>>;
 }

--- a/ncollide_pipeline/narrow_phase/proximity_detector/support_map_support_map_proximity_detector.rs
+++ b/ncollide_pipeline/narrow_phase/proximity_detector/support_map_support_map_proximity_detector.rs
@@ -38,7 +38,7 @@ impl<P, M, S> SupportMapSupportMapProximityDetector<P, M, S>
     }
 }
 
-impl<P, M, S> ProximityDetector<P, M> for SupportMapSupportMapProximityDetector<P, M, S>
+impl<P, M, S: Sync + Send> ProximityDetector<P, M> for SupportMapSupportMapProximityDetector<P, M, S>
     where P: Point,
           M: Isometry<P>,
           S: Simplex<AnnotatedPoint<P>> {

--- a/ncollide_pipeline/narrow_phase/proximity_signal.rs
+++ b/ncollide_pipeline/narrow_phase/proximity_signal.rs
@@ -3,7 +3,7 @@ use world::CollisionObject;
 use math::Point;
 
 /// A signal handler for proximity detection.
-pub trait ProximityHandler<P: Point, M, T> {
+pub trait ProximityHandler<P: Point, M, T> : Sync + Send {
     /// Activate an action for when two objects start or stop to be close to each other.
     fn handle_proximity(&mut self,
                         co1: &CollisionObject<P, M, T>,


### PR DESCRIPTION
I know you are implementing your solution in sync and send branch and I'll take a look at it.
also related to https://github.com/sebcrozet/ncollide/issues/162#issuecomment-327733415

But this is my implementation of things:

It changes some trait to require impl Sync and Send
I don't think if this is too restrictive for some usage but maybe.

dbvt was the only structure that need to be changed to impl Send and Sync
it now uses a DBVTLeaf struct that contains the rc<refcell<DBVTLeafInner>>

to access the previously public fields it contains methods
those methods require a vec of dbvt that is needed for compile time check.