### PR TITLE
fix bug in dbvt2

### DIFF
--- a/ncollide_geometry/partitioning/dbvt2.rs
+++ b/ncollide_geometry/partitioning/dbvt2.rs
@@ -137,6 +137,7 @@ impl<P: Point, B, BV: BoundingVolume<P>> DBVT2<P, B, BV> {
     pub fn insert(&mut self, leaf: DBVTLeaf2<P, B, BV>) -> DBVTLeafId {
         if self.is_empty() {
             let new_id = self.leaves.push(leaf);
+            self.leaves[new_id].parent = DBVTInternalId::Root;
             self.root  = DBVTNodeId::Leaf(new_id);
 
             return DBVTLeafId(new_id);


### PR DESCRIPTION
when insert a leaf into the dbvt if the leaf come from a removal from
another dbvt tree then its parent field can be whatever so it must be
override.

also we could reset parent to Root when removing a leaf ? that would
be more logical