### PR TITLE
Take local compound part transform into account for query::contact computation.

### DIFF
--- a/build/ncollide2d/tests/geometry/compound_penetration.rs
+++ b/build/ncollide2d/tests/geometry/compound_penetration.rs
@@ -3,6 +3,7 @@ use na::{self, Isometry2, Vector2};
 use ncollide2d::query;
 use ncollide2d::shape::{Compound, Cuboid, ShapeHandle};
 
+// Issue #171.
 #[test]
 fn normal() {
   let c1 = Cuboid::new(Vector2::new(1.0, 1.0));
@@ -19,6 +20,7 @@ fn normal() {
   assert!(contact.is_some()); // ok
 }
 
+// Issue #171.
 #[test]
 fn compound() {
   let c1 = Cuboid::new(Vector2::new(1.0, 1.0));

--- a/build/ncollide2d/tests/geometry/compound_penetration.rs
+++ b/build/ncollide2d/tests/geometry/compound_penetration.rs
@@ -1,0 +1,42 @@
+use na::{self, Isometry2, Vector2};
+
+use ncollide2d::query;
+use ncollide2d::shape::{Compound, Cuboid, ShapeHandle};
+
+#[test]
+fn normal() {
+  let c1 = Cuboid::new(Vector2::new(1.0, 1.0));
+  let c2 = Cuboid::new(Vector2::new(1.0, 1.0));
+
+  let contact = query::contact(
+    &Isometry2::new(Vector2::new(10.5, 10.5), na::zero()),
+    &c2,
+    &Isometry2::new(Vector2::new(10.0, 10.0), na::zero()),
+    &c1,
+    1.0,
+  );
+
+  assert!(contact.is_some()); // ok
+}
+
+#[test]
+fn compound() {
+  let c1 = Cuboid::new(Vector2::new(1.0, 1.0));
+  let c2 = Cuboid::new(Vector2::new(1.0, 1.0));
+
+  let shapes = vec![(
+    Isometry2::new(Vector2::new(10.0, 10.0), na::zero()),
+    ShapeHandle::new(c1),
+  )];
+  let compound = Compound::new(shapes);
+
+  let contact = query::contact(
+    &Isometry2::new(Vector2::new(10.5, 10.5), na::zero()),
+    &c2,
+    &Isometry2::identity(),
+    &compound,
+    1.0,
+  );
+
+  assert!(contact.is_some()); // FAILED
+}

--- a/build/ncollide2d/tests/geometry/mod.rs
+++ b/build/ncollide2d/tests/geometry/mod.rs
@@ -2,3 +2,4 @@ mod ball_ball_toi;
 mod epa2;
 mod ray_cast;
 mod time_of_impact2;
+mod compound_penetration;

--- a/src/query/contacts_internal/composite_shape_against_shape.rs
+++ b/src/query/contacts_internal/composite_shape_against_shape.rs
@@ -3,8 +3,8 @@ use na::{self, Real};
 use bounding_volume::BoundingVolume;
 use math::Isometry;
 use partitioning::BoundingVolumeInterferencesCollector;
-use query::Contact;
 use query::contacts_internal;
+use query::Contact;
 use shape::{CompositeShape, Shape};
 
 /// Best contact between a composite shape (`Mesh`, `Compound`) and any other shape.
@@ -32,15 +32,8 @@ where
     let mut res = None::<Contact<N>>;
 
     for i in interferences.into_iter() {
-        g1.map_part_at(
-            i,
-            &mut |_, _, part| match contacts_internal::contact_internal(
-                m1,
-                part,
-                m2,
-                g2,
-                prediction,
-            ) {
+        g1.map_transformed_part_at(i, m1, &mut |_, m, part| {
+            match contacts_internal::contact_internal(m, part, m2, g2, prediction) {
                 Some(c) => {
                     let replace = match res {
                         Some(ref cbest) => c.depth > cbest.depth,
@@ -52,8 +45,8 @@ where
                     }
                 }
                 None => {}
-            },
-        );
+            }
+        });
     }
 
     res


### PR DESCRIPTION
Fix #171.
Maybe related to #209.