### PR TITLE
Add #[repr(transparent)] to CollisionObjectSlabHandle

### DIFF
--- a/src/pipeline/object/collision_object.rs
+++ b/src/pipeline/object/collision_object.rs
@@ -115,6 +115,7 @@ pub trait CollisionObjectRef<N: RealField> {
 
 /// The unique identifier of a collision object stored in a `CollisionObjectSlab` structure.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CollisionObjectSlabHandle(pub usize);
 


### PR DESCRIPTION
Doesn't hurt since it's a simple wrapper for an integer, and helps with C interfacing.

Fixes #349