### PR TITLE
Updated to nalgebra 0.31, Fixed wasm support by indirectly enabling the 'js' feature as fallbac…

### DIFF
--- a/build/ncollide2d/Cargo.toml
+++ b/build/ncollide2d/Cargo.toml
@@ -39,11 +39,12 @@ slab            = "0.4"
 slotmap         = "1"
 petgraph        = "0.6"
 simba           = "0.7"
-nalgebra        = "0.30"
+nalgebra        = "0.31"
 approx          = { version = "0.5", default-features = false }
 serde           = { version = "1.0", optional = true, features = ["derive"]}
 
 [dev-dependencies]
-nalgebra = { version = "0.30", features = ["rand"] }
+nalgebra = { version = "0.31", features = ["rand"] }
+getrandom = { version = "0.2", features = ["js"] }
 rand     = { version = "0.8" }
 simba    = { version = "0.7", features = [ "partial_fixed_point_support" ] }

--- a/build/ncollide3d/Cargo.toml
+++ b/build/ncollide3d/Cargo.toml
@@ -39,11 +39,12 @@ slab       = "0.4"
 slotmap    = "1"
 petgraph   = "0.6"
 simba      = "0.7"
-nalgebra   = "0.30"
+nalgebra   = "0.31"
 approx     = { version = "0.5", default-features = false }
 serde      = { version = "1.0", optional = true, features = ["derive", "rc"]}
 
 [dev-dependencies]
-nalgebra   = { version = "0.30", features = ["rand"] }
+nalgebra   = { version = "0.31", features = ["rand"] }
+getrandom = { version = "0.2", features = ["js"] }
 rand       = { version = "0.8" }
 rand_isaac = "0.3"


### PR DESCRIPTION
So this seems to be a bottleneck towards updating the nalgebra version, which is having issues for upstream crates. I noticed that the only thing preventing a direct upgrade was this error

```imp::getrandom_inner(dest)
    |     ^^^ use of undeclared crate or module `imp`
```

Which after some searching, was an issue with the `rand` crate relying on `getrandom` and its "js" feature. After following the Indirect Dependencies steps, all of the tests in `cargo test` passed and the CircleCI passed.

Hopefully this should be a relatively instant PR for updating nalgebra to the latest version.