### PR TITLE
Bump nalgebra to 0.32

### DIFF
--- a/build/ncollide2d/Cargo.toml
+++ b/build/ncollide2d/Cargo.toml
@@ -38,12 +38,12 @@ smallvec        = "1"
 slab            = "0.4"
 slotmap         = "1"
 petgraph        = "0.6"
-simba           = "0.7"
-nalgebra        = "0.30"
+simba           = "0.8"
+nalgebra        = "0.32"
 approx          = { version = "0.5", default-features = false }
 serde           = { version = "1.0", optional = true, features = ["derive"]}
 
 [dev-dependencies]
-nalgebra = { version = "0.30", features = ["rand"] }
+nalgebra = { version = "0.32", features = ["rand"] }
 rand     = { version = "0.8" }
-simba    = { version = "0.7", features = [ "partial_fixed_point_support" ] }
+simba    = { version = "0.8", features = [ "partial_fixed_point_support" ] }

--- a/build/ncollide3d/Cargo.toml
+++ b/build/ncollide3d/Cargo.toml
@@ -38,12 +38,12 @@ smallvec   = "1"
 slab       = "0.4"
 slotmap    = "1"
 petgraph   = "0.6"
-simba      = "0.7"
-nalgebra   = "0.30"
+simba      = "0.8"
+nalgebra   = "0.32"
 approx     = { version = "0.5", default-features = false }
 serde      = { version = "1.0", optional = true, features = ["derive", "rc"]}
 
 [dev-dependencies]
-nalgebra   = { version = "0.30", features = ["rand"] }
+nalgebra   = { version = "0.32", features = ["rand"] }
 rand       = { version = "0.8" }
 rand_isaac = "0.3"


### PR DESCRIPTION
Bumping `nalgebra` to the latest version (0.32). `simba` also needs update to 0.8, to remain compatible. No changes in code required.